### PR TITLE
Sanitize create-payment-intent errors and harden payload

### DIFF
--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -672,8 +672,9 @@ class CreatePaymentIntentSecurityTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+        self.assertIn("shipping_details", response.data)
         self.assertEqual(
-            response.data["shipping_details"],
+            response.data["shipping_details"]["address"],
             "Invalid shipping_details payload. Expected an object.",
         )
         mock_create.assert_not_called()
@@ -701,6 +702,29 @@ class CreatePaymentIntentSecurityTests(TestCase):
         self.assertEqual(response.data["code"], "INVALID_CART_PAYLOAD")
         self.assertEqual(response.data["error"], "Invalid cart data provided.")
         self.assertNotIn("product_id", json.dumps(response.data))
+        mock_create.assert_not_called()
+
+    @patch("checkout.views.stripe.PaymentIntent.create")
+    def test_non_object_cart_item_returns_sanitized_400(self, mock_create):
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "cart": [
+                "not-an-object",
+            ],
+            "shipping_details": {"email": "buyer@example.com"},
+        }
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["code"], "INVALID_CART_PAYLOAD")
+        self.assertEqual(
+            response.data["error"],
+            "Invalid cart item payload. Expected an object.",
+        )
         mock_create.assert_not_called()
 
     @patch("checkout.views.stripe.PaymentIntent.create")

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -51,17 +51,21 @@ class CreatePaymentIntentView(APIView):
         # NEW: Get the selected shipping method from the frontend (default to budget)
         shipping_method = request.data.get('shipping_method', 'budget')
         
-        if not cart:
+        if cart is None:
             return Response({"error": "Cart is empty."}, status=status.HTTP_400_BAD_REQUEST)
         if not isinstance(cart, list):
             return Response(
                 {"error": "Invalid cart payload. Expected a list of cart items."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        if len(cart) == 0:
+            return Response({"error": "Cart is empty."}, status=status.HTTP_400_BAD_REQUEST)
         if shipping_details is not None and not isinstance(shipping_details, dict):
             return Response(
                 {
-                    "shipping_details": "Invalid shipping_details payload. Expected an object."
+                    "shipping_details": {
+                        "address": "Invalid shipping_details payload. Expected an object."
+                    }
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
@@ -137,7 +141,10 @@ class CreatePaymentIntentView(APIView):
             for item in cart:
                 if not isinstance(item, dict):
                     return Response(
-                        {"error": "Invalid cart item payload. Expected an object."},
+                        {
+                            "code": "INVALID_CART_PAYLOAD",
+                            "error": "Invalid cart item payload. Expected an object.",
+                        },
                         status=status.HTTP_400_BAD_REQUEST,
                     )
                 product_id = item['product_id']
@@ -184,7 +191,14 @@ class CreatePaymentIntentView(APIView):
                         )
                         shipping_cost += float(shipping_rule.cost) * quantity
                     except (PrintTemplate.DoesNotExist, ProductShipping.DoesNotExist):
-                        print(f"Warning: No shipping rule for {product_instance.material} {product_instance.size} to {shipping_country}")
+                        logger.warning(
+                            "No shipping rule found for checkout item "
+                            "(material=%s, size=%s, country=%s, method=%s)",
+                            product_instance.material,
+                            product_instance.size,
+                            shipping_country,
+                            shipping_method,
+                        )
                         # You could add a fallback flat rate here if desired
 
         except (KeyError, TypeError, ValueError, ObjectDoesNotExist) as e:


### PR DESCRIPTION
Closes #72 

## Summary

This PR hardens `create-payment-intent` error handling to prevent internal exception leakage and improves defensive request payload validation. It standardizes client-facing error contracts for malformed cart/shipping payloads and Stripe intent creation failures.

## Why

`create-payment-intent` could return raw exception strings to clients, leaking internal implementation details.  
It also had payload-shape edge cases that could raise server errors instead of returning clean validation responses.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Added strict validation for `shipping_details` payload shape (must be object when provided)
  - Added sanitized `400` error contract for invalid cart item parsing:
    - `code: INVALID_CART_PAYLOAD`
    - generic message without internal exception text
  - Kept sanitized `500` error contract for Stripe intent creation failures:
    - `code: PAYMENT_INTENT_CREATION_FAILED`
  - Added structured server-side logging for diagnostics (`logger.warning` / `logger.exception`)
  - Added regression tests:
    - non-dict `shipping_details` rejected
    - malformed cart item returns sanitized `400`
    - Stripe exception returns sanitized `500` without internal text
- Frontend:
  - No changes
- Infra/Config:
  - No changes

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described:
  - Revert `CreatePaymentIntentView` payload validation/error-contract changes in `checkout/views.py`
  - Re-run checkout test suite

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
