### PR TITLE
Replace random DB sort with scalable ID-anchor

### DIFF
--- a/products/tests.py
+++ b/products/tests.py
@@ -190,6 +190,28 @@ class LicenseRequestTests(APITestCase):
         self.assertIn(active.id, returned_ids)
         self.assertNotIn(inactive.id, returned_ids)
 
+    def test_bag_recommendations_uses_row_offset_sampling_over_active_rows(self):
+        Photo.objects.update(is_active=False)
+        active_a = self._create_photo(is_active=True)
+        self._create_photo(is_active=False)  # gap
+        active_b = self._create_photo(is_active=True)
+        self._create_photo(is_active=False)  # gap
+        active_c = self._create_photo(is_active=True)
+        active_d = self._create_photo(is_active=True)
+        active_e = self._create_photo(is_active=True)
+        active_ids = [active_a.id, active_b.id, active_c.id, active_d.id, active_e.id]
+
+        with patch("products.views.random.randint", return_value=3) as mocked_randint:
+            response = self.client.get(reverse("bag-recommendations"))
+
+        self.assertEqual(response.status_code, 200)
+        mocked_randint.assert_called_once_with(0, len(active_ids) - 1)
+        # Start at offset 3 => D, E, then wrap to A, B
+        self.assertEqual(
+            [item["id"] for item in response.data],
+            [active_d.id, active_e.id, active_a.id, active_b.id],
+        )
+
     def test_license_request_message_max_length(self):
         payload = self._payload(message="a" * 3000)
         response = self.client.post(self.url, payload, format="json")

--- a/products/views.py
+++ b/products/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import get_object_or_404
 from django.core.exceptions import PermissionDenied
 from django.http import FileResponse, Http404, HttpResponse
 from django.db import transaction
-from django.db.models import Q, Exists, OuterRef, Min, Max, Case, When, IntegerField
+from django.db.models import Q, Exists, OuterRef, Min, Case, When, IntegerField
 from django.db.models.functions import Coalesce
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail import send_mail
@@ -439,34 +439,30 @@ class ProductReviewListCreateView(generics.ListCreateAPIView):
     
 class ShoppingBagRecommendationsView(APIView):
     """
-    Returns 4 random photos to display as recommendations 
+    Returns up to 4 active photos to display as recommendations
     on the Shopping Bag / Cart page.
     """
     permission_classes = [AllowAny]
     RECOMMENDATION_LIMIT = 4
 
     def _pick_recommendation_ids(self, queryset, limit):
-        bounds = queryset.aggregate(min_id=Min('id'), max_id=Max('id'))
-        min_id = bounds.get('min_id')
-        max_id = bounds.get('max_id')
-        if min_id is None or max_id is None:
+        total = queryset.count()
+        if total == 0:
             return []
+        if total <= limit:
+            return list(queryset.order_by('-created_at').values_list('id', flat=True))
 
-        # Random anchor avoids expensive ORDER BY RANDOM() on large tables.
-        anchor = random.randint(min_id, max_id)
+        # Random start index is unbiased across active rows and avoids
+        # expensive ORDER BY RANDOM() on large tables.
+        start_index = random.randint(0, total - 1)
+        ordered_ids = queryset.order_by('id').values_list('id', flat=True)
         ids = list(
-            queryset
-            .filter(id__gte=anchor)
-            .order_by('id')
-            .values_list('id', flat=True)[:limit]
+            ordered_ids[start_index:start_index + limit]
         )
         if len(ids) < limit:
             ids.extend(
                 list(
-                    queryset
-                    .filter(id__lt=anchor)
-                    .order_by('id')
-                    .values_list('id', flat=True)[: limit - len(ids)]
+                    ordered_ids[: limit - len(ids)]
                 )
             )
         return ids


### PR DESCRIPTION
Closes #74 

## Summary

This PR fixes the shopping bag recommendations DB performance issue by removing `ORDER BY RANDOM()` (`order_by('?')`) and replacing it with a scalable random ID-anchor selection strategy. It also hardens the final fetch to exclude inactive photos and adds regression tests.

## Why

`order_by('?')` is expensive and degrades as product rows grow, especially on production databases.  
The endpoint is hot-path traffic for the bag/cart page, so query scalability matters.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Replaced recommendations query strategy in `ShoppingBagRecommendationsView`:
    - from full random sort
    - to random ID-anchor + indexed range selection + wrap-around
  - Removed extra `count()` query in recommendation selection path
  - Added `is_active=True` to final recommendation fetch (race-safe filtering)
  - Preserved output order with `Case/When`
  - Added tests:
    - returns up to 4 active photos
    - returns empty list when none active
    - filters inactive IDs even if selected pool includes them
- Frontend:
  - No changes
- Infra/Config:
  - No changes

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described:
  - restore previous recommendations query in `products/views.py`
  - keep tests for future optimization work if needed

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [ ] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (query plan, DB load, hot-path efficiency)
- [x] Maintainability (query readability, test coverage)
