### PR TITLE
docs(backend): add production-grade repository documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,187 @@
-# openeire-api
+# OpenEire API (Django Backend)
+
+## Overview
+This repository contains the backend API for OpenEire Studios. It is a Django + Django REST Framework service that powers authentication, product catalog access, checkout, licensing, blog content, and home-page form endpoints.
+
+## Backend Responsibilities
+- User registration, verification, authentication, profile management, and account lifecycle.
+- Product and gallery APIs for photos, videos, physical variants, reviews, and secure downloads.
+- Checkout and payment workflows with Stripe webhooks and order history.
+- Rights-managed licensing request flow, quote/payment handling, document generation, and delivery tokens.
+- Blog post/comment APIs with server-side sanitization.
+- Support APIs for testimonials, newsletter signup, and contact form submission.
+
+## Tech Stack
+- Python 3.12+
+- Django 4.2
+- Django REST Framework
+- SimpleJWT (`djangorestframework-simplejwt`)
+- Stripe SDK
+- Redis cache backend (for shared throttling state when configured)
+- Cloudflare R2 / S3-compatible storage (`django-storages`, `boto3`)
+- Email via SMTP (Brevo relay configured in settings)
+- Django allauth + dj-rest-auth (including Google social login)
+
+## Repository Structure
+```text
+openeire-api/
+  openeire_api/        # Project settings, URL root, cache/throttle config, custom admin
+  userprofiles/        # Auth/profile endpoints, serializers, token utilities, profile model
+  products/            # Catalog, downloads, licensing requests, internal worker endpoints
+  checkout/            # Payment intent, Stripe webhook processing, order history, fulfillment
+  blog/                # Blog post/comment APIs and sanitization
+  home/                # Testimonials, newsletter signup, contact form
+  templates/           # Email and admin templates
+  .github/workflows/   # CI workflow
+```
+
+## Local Development Setup
+1. Create and activate a virtual environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Create a local `.env` file (see "Environment Variables").
+4. Run migrations:
+   ```bash
+   python manage.py migrate
+   ```
+5. Start the API server:
+   ```bash
+   python manage.py runserver
+   ```
+
+## Environment Variables
+Only variables observed in code are listed below. Values/secrets are `Configuration Required`.
+
+Core/security:
+- `DEBUG`
+- `SECRET_KEY`
+- `ENFORCE_STRONG_SECRET_KEY`
+- `DJANGO_ADMIN_URL`
+- `APP_ENV`
+- `RENDER_ENVIRONMENT`
+
+Hosts/CORS/CSRF/security:
+- `RENDER_EXTERNAL_HOSTNAME`
+- `SECURE_SSL_REDIRECT`
+- `SESSION_COOKIE_SECURE`
+- `CSRF_COOKIE_SECURE`
+- `SESSION_COOKIE_SAMESITE`
+- `CSRF_COOKIE_SAMESITE`
+- `SECURE_HSTS_SECONDS`
+- `SECURE_HSTS_INCLUDE_SUBDOMAINS`
+- `SECURE_HSTS_PRELOAD`
+- `SECURE_REFERRER_POLICY`
+- `X_FRAME_OPTIONS`
+
+JWT/auth cookie mode:
+- `JWT_USE_HTTPONLY_COOKIES`
+- `JWT_ACCESS_COOKIE_NAME`
+- `JWT_REFRESH_COOKIE_NAME`
+- `JWT_COOKIE_SECURE`
+- `JWT_COOKIE_SAMESITE`
+- `JWT_COOKIE_DOMAIN`
+- `JWT_COOKIE_CSRF_PROTECTION`
+- `JWT_CSRF_COOKIE_NAME`
+- `JWT_CSRF_HEADER_NAME`
+- `EMAIL_VERIFICATION_TOKEN_MINUTES`
+- `PASSWORD_RESET_TOKEN_MINUTES`
+
+Cache/throttling:
+- `CACHE_REDIS_URL` or `REDIS_URL`
+- `CACHE_KEY_PREFIX`
+- `CACHE_REDIS_CONNECT_TIMEOUT_SECONDS`
+- `CACHE_REDIS_SOCKET_TIMEOUT_SECONDS`
+- `REQUIRE_SHARED_THROTTLE_CACHE`
+- `THROTTLE_FAIL_OPEN`
+
+Storage (R2/S3):
+- `R2_ACCESS_KEY_ID`
+- `R2_SECRET_ACCESS_KEY`
+- `R2_BUCKET_NAME`
+- `R2_ENDPOINT_URL`
+- `R2_CUSTOM_DOMAIN`
+- `R2_PRIVATE_BUCKET_NAME`
+- `R2_PRIVATE_ACCESS_KEY_ID`
+- `R2_PRIVATE_SECRET_ACCESS_KEY`
+
+Email:
+- `EMAIL_HOST_USER`
+- `EMAIL_HOST_PASSWORD`
+
+Stripe:
+- `STRIPE_PUBLIC_KEY`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `STRIPE_TIMEOUT_SECONDS`
+- `STRIPE_MAX_NETWORK_RETRIES`
+- `STRIPE_WEBHOOK_STALE_PROCESSING_SECONDS`
+- `CHECKOUT_ALLOW_LEGACY_USERNAME_FALLBACK`
+
+Prodigi:
+- `PRODIGI_API_KEY`
+- `PRODIGI_SANDBOX`
+- `PRODIGI_CONNECT_TIMEOUT_SECONDS`
+- `PRODIGI_READ_TIMEOUT_SECONDS`
+- `SITE_URL`
+
+Licensing/AI worker:
+- `LICENCE_DOWNLOAD_BASE_URL`
+- `LICENCE_DELIVERY_TOKEN_DAYS`
+- `LICENCE_SEND_INITIAL_DRAFT_EMAIL`
+- `LICENCE_TERMS_VERSION`
+- `LICENCE_MASTER_AGREEMENT`
+- `AI_WORKER_SECRET`
+- `AI_WORKER_IP_ALLOWLIST`
+- `AI_WORKER_TRUSTED_PROXY_IPS`
+- `AI_WORKER_MAX_BATCH`
+- `AI_WORKER_MAX_BATCH_HARD`
+- `AI_DRAFT_MAX_CHARS`
+
+Blog sanitization:
+- `BLOG_ALLOWED_IMAGE_HOSTS`
+
+SQLite tuning (default DB engine in settings):
+- `SQLITE_TIMEOUT_SECONDS`
+- `SQLITE_SAVE_RETRY_ATTEMPTS`
+- `SQLITE_SAVE_RETRY_DELAY_SECONDS`
+
+## Running the Server
+```bash
+python manage.py runserver
+```
+
+Useful commands:
+```bash
+python manage.py check
+python manage.py migrate
+python manage.py test
+python manage.py collectstatic --no-input
+```
+
+## Background Worker Overview
+- Celery tasks are not defined in this repository (`Configuration Required` if you plan to add Celery).
+- There is an internal AI-draft integration exposed as protected API endpoints:
+  - `GET /api/internal/draft-queue/`
+  - `POST /api/internal/draft-update/<pk>/`
+- Access is controlled by a bearer secret (`AI_WORKER_SECRET`) and optional IP allowlist checks.
+
+## API Overview
+Primary route groups:
+- ` /api/auth/` - authentication and user profile APIs
+- ` /api/` - products, gallery, downloads, licensing
+- ` /api/checkout/` - payment intents, webhooks, order history
+- ` /api/blog/` - blog posts, likes, comments
+- ` /api/home/` - testimonials, newsletter, contact
+
+Detailed endpoint contracts are documented in [docs/api.md](docs/api.md).
+
+## Deployment Reference
+See:
+- [docs/deployment.md](docs/deployment.md)
+- [docs/operations.md](docs/operations.md)
+
+## Maintainer
+- Project/team owner: Configuration Required
+- Primary backend maintainer: Configuration Required

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,363 @@
+# API Reference
+
+## Conventions
+- Base prefix: `/api/`
+- Auth scheme: JWT Bearer (`Authorization: Bearer <access_token>`) by default.
+- Some deployments may also enable HttpOnly JWT cookie mode (`Configuration Required` via env).
+- Unless overridden per-view, DRF default permission is authenticated. Most public endpoints explicitly set `AllowAny`.
+- Pagination:
+  - Gallery/blog liked/blog list use DRF pagination where configured.
+
+No DRF routers were detected; endpoints are path-based class views.
+
+---
+
+## Authentication and User (`/api/auth/`)
+
+### `POST /api/auth/register/`
+- Purpose: Create user account (inactive until email verification).
+- Auth: Public.
+- Request:
+  - `username` (string, required)
+  - `email` (email, required, case-insensitive unique)
+  - `password` (string, required)
+  - `first_name` (string, optional)
+  - `last_name` (string, optional)
+- Response: Created user fields (excluding password), `201`.
+
+### `POST /api/auth/verify-email/confirm/`
+- Purpose: Activate account using action token.
+- Auth: Public.
+- Request:
+  - `token` (string, required)
+- Response:
+  - Success: `{ "message": "Email successfully verified!" }`
+  - Error: `{ "error": "Invalid activation link." }`
+
+### `POST /api/auth/resend-verification/`
+- Purpose: Re-send verification email.
+- Auth: Public.
+- Request:
+  - `email` (email, required)
+- Response: Generic success message (`200`) regardless of account discoverability.
+
+### `POST /api/auth/login/`
+- Purpose: Obtain JWT access/refresh tokens.
+- Auth: Public.
+- Request:
+  - `username` (string; serializer accepts username or email-form identifier)
+  - `password` (string)
+- Response:
+  - `access`, `refresh` tokens (`200`)
+  - If cookie mode enabled, cookies are set as side-effect.
+
+### `POST /api/auth/token/refresh/`
+- Purpose: Refresh JWT access token.
+- Auth: Public endpoint semantics; token validation enforced by serializer.
+- Request:
+  - `refresh` (string) or refresh cookie when cookie mode is enabled.
+- Response:
+  - New `access` and possibly rotated `refresh`.
+
+### `POST /api/auth/logout/`
+- Purpose: Clear auth cookies.
+- Auth: Public (`AllowAny`).
+- Request:
+  - Empty body.
+  - In cookie mode with auth cookies present, CSRF header/cookie match is required.
+- Response:
+  - `{ "message": "Logged out." }`
+
+### `POST /api/auth/password/reset/`
+- Purpose: Send password reset email.
+- Auth: Public.
+- Request:
+  - `email` (email, required)
+- Response:
+  - Generic `{ "message": "Password reset link sent." }` (`200`).
+
+### `POST /api/auth/password/reset/confirm/`
+- Purpose: Complete password reset with token.
+- Auth: Public.
+- Request:
+  - `token` (string)
+  - `password` (string)
+  - `confirm_password` (string)
+- Response:
+  - Success `{ "message": "Password reset successful." }`
+  - Failure `{ "error": "Invalid or expired token." }`
+
+### `PUT/PATCH /api/auth/password/change/`
+- Purpose: Change password for authenticated user.
+- Auth: Authenticated.
+- Request:
+  - `old_password` (string)
+  - `new_password` (string)
+- Response:
+  - `{ "message": "Password updated successfully" }`
+
+### `PUT/PATCH /api/auth/email/change/`
+- Purpose: Change account email and force re-verification.
+- Auth: Authenticated.
+- Request:
+  - `new_email` (email)
+  - `current_password` (string)
+- Response:
+  - Success message; account is set inactive pending verification.
+
+### `GET/PUT/PATCH /api/auth/profile/`
+- Purpose: Read/update current profile.
+- Auth: Authenticated.
+- Request update fields:
+  - `username`, `first_name`, `last_name`, `email`
+  - `default_phone_number`, `default_street_address1`, `default_street_address2`
+  - `default_town`, `default_county`, `default_postcode`, `country`
+- Response: Profile + user identity fields.
+
+### `DELETE /api/auth/delete/`
+- Purpose: Delete authenticated account.
+- Auth: Authenticated.
+- Request:
+  - `password` (string, required in request body)
+- Response:
+  - `204` with `{ "message": "Account deleted successfully." }`
+
+### `GET /api/auth/countries/`
+- Purpose: Return countries for UI dropdowns.
+- Auth: Public.
+- Response:
+  - Array of `{ "code": "...", "name": "..." }`.
+
+### `POST /api/auth/google/`
+- Purpose: Google social login via allauth/dj-rest-auth.
+- Auth: Public.
+- Request/response shape: Provider flow dependent (`Configuration Required` frontend integration details).
+
+---
+
+## Products, Gallery, Licensing (`/api/`)
+
+### `GET /api/licence/personal-use/`
+- Purpose: Return personal-use license full text.
+- Auth: Public.
+- Response:
+  - Plain text body with terms version header `X-Personal-Terms-Version`.
+
+### `POST /api/gallery-request/`
+- Purpose: Issue gallery access code to email.
+- Auth: Public.
+- Throttle scope: `gallery_access_request`.
+- Request:
+  - `email`
+- Response:
+  - `{ "message": "Code sent" }`
+
+### `POST /api/gallery-verify/`
+- Purpose: Validate gallery access code.
+- Auth: Public.
+- Throttle scope: `gallery_access_verify`.
+- Request:
+  - `access_code`
+- Response:
+  - Success: `{ "message": "Access granted", "expires_at": "...", "valid": true }`
+  - Failure: `403` with error.
+
+### `GET /api/gallery/`
+- Purpose: List gallery products with filtering.
+- Auth:
+  - Public for physical view.
+  - Digital view requires `X-Gallery-Access-Token` header.
+- Query params:
+  - `type` (`physical`, `digital`, `all`; defaults to physical path)
+  - `collection`
+  - `search`
+  - `sort` (`price_asc`, `price_desc`, default date descending)
+  - `page`, `page_size` (when paginated)
+- Response:
+  - Mixed list of serialized photo/video/physical photo list payloads.
+
+### `GET /api/photos/<pk>/`
+- Purpose: Digital photo detail.
+- Auth: Requires digital gallery access header token.
+- Response:
+  - Photo detail including pricing, related items, variants, review stats.
+
+### `GET /api/videos/<pk>/`
+- Purpose: Video detail.
+- Auth: Requires digital gallery access header token.
+- Response:
+  - Video detail including pricing, metadata, related items, review stats.
+
+### `GET /api/products/<pk>/`
+- Purpose: Physical photo detail page payload.
+- Auth: Public.
+
+### `GET /api/variants/<pk>/`
+- Purpose: Physical product variant detail.
+- Auth: Public.
+
+### `GET/POST /api/<product_type>/<pk>/reviews/`
+- Purpose:
+  - `GET`: list approved reviews for product.
+  - `POST`: create review for authenticated user (one review/user/product).
+- Auth:
+  - `GET` public.
+  - `POST` authenticated.
+- Request (`POST`):
+  - `rating` (1-5)
+  - `comment` (optional)
+- Response:
+  - Review objects with `user`, `rating`, `comment`, `created_at`, `admin_reply`.
+
+### `GET /api/products/recommendations/`
+- Purpose: Return up to 4 active photo recommendations.
+- Auth: Public.
+
+### `GET /api/products/download/<product_type>/<product_id>/`
+- Purpose: Secure purchased digital asset download.
+- Auth: Authenticated.
+- Rules:
+  - Requires prior purchase in order history, unless staff user.
+  - Optional `?preview=1` returns metadata instead of file stream.
+- Response:
+  - File attachment stream, or preview metadata JSON.
+
+### `POST /api/license-requests/`
+- Purpose: Create commercial license request(s) for photo/video assets.
+- Auth: Public.
+- Throttle scope: `license_request`.
+- Request (single):
+  - `asset_type` (`photo` or `video`)
+  - `asset_id` (int)
+  - `client_name`, `company`, `email`
+  - `project_type`, `duration`, optional `territory`, `permitted_media`, `exclusivity`, `reach_caps`, `message`
+- Request (batch):
+  - `asset_ids` array + same shared request fields
+- Response:
+  - `201` created object(s) or mixed `207` with partial errors.
+
+### `GET /api/license/download/<uuid:token>/`
+- Purpose: One-time expiring licensed asset download link.
+- Auth: Public by token.
+- Response:
+  - File attachment if token valid and unused.
+  - `404` when invalid/expired/used.
+
+### `GET /api/internal/draft-queue/`
+- Purpose: Internal AI worker pulls pending license requests.
+- Auth: Internal bearer secret + optional IP allowlist.
+- Query params:
+  - `limit` (bounded by `AI_WORKER_MAX_BATCH_HARD`)
+- Response:
+  - Array of pending request summaries.
+
+### `POST /api/internal/draft-update/<pk>/`
+- Purpose: Internal AI worker submits draft response text.
+- Auth: Internal bearer secret + optional IP allowlist.
+- Request:
+  - `draft_text` (string, max `AI_DRAFT_MAX_CHARS`)
+- Response:
+  - Success/failure status JSON with `200/404/409`.
+
+---
+
+## Checkout (`/api/checkout/`)
+
+### `POST /api/checkout/create-payment-intent/`
+- Purpose: Validate cart and create Stripe PaymentIntent.
+- Auth:
+  - Public for physical-only carts.
+  - Digital items require authenticated user.
+- Request:
+  - `cart` (required array)
+    - item fields include `product_id`, `product_type` (`photo`, `video`, `physical`), `quantity`, optional `options`
+  - `shipping_details` (object, required for physical items)
+  - `shipping_method` (`budget` default, `standard`, `express`)
+  - `save_info` (optional boolean-like)
+- Response:
+  - `{ "clientSecret", "shippingCost", "totalPrice" }`
+  - Validation errors for invalid cart/address/options.
+
+### `POST /api/checkout/wh/`
+- Purpose: Stripe webhook receiver.
+- Auth: Public (signature-verified).
+- Supported events:
+  - `payment_intent.succeeded`
+  - `checkout.session.completed`
+- Behavior:
+  - Idempotency tracked in `StripeWebhookEvent`
+  - Creates orders from cart metadata
+  - Sends confirmation emails
+  - Triggers Prodigi for physical items
+  - Processes licensing payment completion and delivery
+- Response:
+  - `200` (including for safely ignored/replayed events), `400` on invalid signature.
+
+### `GET /api/checkout/order-history/`
+- Purpose: List authenticated user's past orders.
+- Auth: Authenticated.
+- Response:
+  - Order list with totals, shipping, terms version, and item-level product payload + download URLs for digital items.
+
+---
+
+## Blog (`/api/blog/`)
+
+### `GET /api/blog/`
+- Purpose: List published posts.
+- Auth: Public.
+- Query params:
+  - `tag` (slug)
+  - pagination params
+- Response:
+  - Paginated blog list serializer output.
+
+### `GET /api/blog/liked/`
+- Purpose: List posts liked by current user.
+- Auth: Authenticated.
+
+### `GET /api/blog/<slug>/`
+- Purpose: Retrieve published blog detail by slug.
+- Auth: Public.
+- Response:
+  - Includes sanitized `content`, likes metadata, and related posts.
+
+### `POST /api/blog/<slug>/like/`
+- Purpose: Toggle like/unlike for authenticated user.
+- Auth: Authenticated.
+- Response:
+  - `{ "liked": <bool>, "likes_count": <int> }`
+
+### `GET/POST /api/blog/<slug>/comments/`
+- Purpose:
+  - `GET`: list approved comments
+  - `POST`: create comment (pending approval by default model behavior)
+- Auth:
+  - `GET` public
+  - `POST` authenticated
+- Request (`POST`):
+  - `content` (string)
+- Response:
+  - Comment serializer payload.
+
+---
+
+## Home (`/api/home/`)
+
+### `GET /api/home/testimonials/`
+- Purpose: List testimonials.
+- Auth: Public.
+
+### `POST /api/home/newsletter-signup/`
+- Purpose: Add newsletter subscriber.
+- Auth: Public.
+- Request:
+  - `email`
+
+### `POST /api/home/contact/`
+- Purpose: Submit contact form and send email to configured recipient.
+- Auth: Public.
+- Request:
+  - `name`, `email`, `subject`, `message`
+- Response:
+  - Success message or generic email failure error.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,105 @@
+# Architecture
+
+## High-Level Structure
+This backend is a modular Django project with app-level domain boundaries.
+
+- Project package: `openeire_api`
+- Domain apps: `userprofiles`, `products`, `checkout`, `blog`, `home`
+- API stack: Django REST Framework class-based views
+- Auth stack: SimpleJWT + dj-rest-auth/allauth (+ Google provider)
+
+## Installed Apps and Responsibilities
+Observed from `INSTALLED_APPS`:
+
+- `userprofiles`
+  - Registration, login, token refresh/logout, password/email/account flows
+  - `UserProfile` model linked to Django `User`
+  - One-off action tokens for email verification and password reset
+- `products`
+  - Catalog APIs (photos, videos, physical variants)
+  - Review APIs and secure media download endpoints
+  - Commercial license request pipeline and delivery-token download flow
+  - Internal AI draft queue/update endpoints
+- `checkout`
+  - Stripe payment intent creation
+  - Stripe webhook processing for orders and license delivery
+  - Order history and physical fulfillment integration (Prodigi)
+- `blog`
+  - Blog listing/detail/like/comment APIs
+  - HTML/plain-text sanitization pipeline
+- `home`
+  - Testimonials, newsletter signups, contact form endpoint
+
+## Service Layer Pattern
+A dedicated service module layer is used in selected domains:
+
+- `products/licensing.py`
+  - Generates and persists license documents
+  - Issues one-time delivery tokens
+  - Sends licensing emails
+- `checkout/prodigi.py`
+  - Builds and submits fulfillment payloads to Prodigi
+  - Handles timeout/error parsing
+- `products/personal_licence.py`, `products/pdf_generator.py`
+  - License text/version helpers and PDF generation
+
+Most other logic is view/serializer centric (standard DRF pattern).
+
+## Async Processing Architecture
+No Celery app/tasks were found in the repository (`Configuration Required` for Celery adoption).
+
+Current async-like external processing pattern:
+- Internal protected API endpoints are used by a separate worker process to pull and submit AI draft responses.
+- Stripe webhook callbacks are synchronous HTTP handlers with idempotency tracking via `StripeWebhookEvent`.
+
+## Integration Points
+- Stripe: payment intents, webhooks, payment links (licensing offers)
+- Prodigi: physical print fulfillment API
+- Email SMTP: transactional emails (verification, reset, order/licensing updates)
+- Cloudflare R2 (S3-compatible): media storage (public + private)
+- Redis cache backend: shared throttling/cache when configured
+- Google OAuth: allauth social login endpoint
+
+## Request Lifecycle
+1. Client calls API endpoint under `/api/...`.
+2. Django URL routing dispatches to app-specific DRF view.
+3. Permissions + throttling execute (`SharedScopedRateThrottle` for selected endpoints).
+4. Serializer validation + domain logic run.
+5. Data is persisted via Django ORM (or external provider calls are made).
+6. Response payload is serialized and returned.
+
+## Diagram: Core Request Path
+```text
+Client -> API -> Business Logic -> Database
+
+Expanded:
+Client
+  -> Django URL Router
+  -> DRF View / Permissions / Throttle
+  -> Serializer + Domain Logic
+  -> Django ORM
+  -> Database
+  -> Response
+```
+
+## Diagram: External Processing Path
+```text
+API/Webhook
+  -> Domain Logic
+  -> External Service (Stripe/Prodigi/SMTP)
+  -> Persist status/audit events
+```
+
+## Diagram: Celery Pattern (Configuration Required)
+```text
+API -> Celery Queue -> Worker -> External Service
+```
+
+## Diagram: Internal Worker Path
+```text
+AI Worker (separate process)
+  -> GET /api/internal/draft-queue/
+  -> Generate draft externally
+  -> POST /api/internal/draft-update/<id>/
+  -> LicenseRequest updated in DB
+```

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,207 @@
+# Database Model Reference
+
+## Overview
+The project uses Django ORM models across five domain apps. In `settings.py`, the default configured engine is SQLite. CI includes PostgreSQL service configuration, but runtime DB switching is `Configuration Required` because `DATABASE_URL` is not consumed in current settings.
+
+## Core Entities
+
+### `auth.User` (Django built-in)
+- Used for platform authentication identity.
+- Related to:
+  - `UserProfile` (one-to-one)
+  - Blog authoring, likes, comments
+  - Product reviews
+  - License offer/audit attribution
+
+### `userprofiles.UserProfile`
+- Purpose: Persist user profile + default delivery fields.
+- Key fields:
+  - `user` (OneToOne to `auth.User`)
+  - `default_phone_number`, `default_street_address1/2`, `default_town`, `default_county`, `default_postcode`, `default_country`
+  - `can_access_gallery` (bool)
+
+### `products.Photo`
+- Purpose: Digital photo asset and physical parent for variants.
+- Key fields:
+  - `title`, `description`, `collection`, `tags`, `is_active`
+  - `preview_image` (public media)
+  - `high_res_file` (private asset storage)
+  - `price_hd`, `price_4k`
+  - `created_at`
+- Related to:
+  - `ProductVariant` (one-to-many)
+  - Generic references from reviews/license requests/order items
+
+### `products.Video`
+- Purpose: Digital video asset.
+- Key fields:
+  - `title`, `description`, `collection`, `tags`, `is_active`
+  - `thumbnail_image` (public)
+  - `video_file` (private)
+  - `price_hd`, `price_4k`
+  - `duration`, `resolution`, `frame_rate`
+  - `created_at`
+
+### `products.ProductVariant`
+- Purpose: Physical print SKU for a photo/material/size combination.
+- Key fields:
+  - `photo` (FK to `Photo`)
+  - `material`, `size`, `price`, `sku`, `prodigi_sku`
+- Constraints:
+  - Unique together: `(photo, material, size)`
+
+### `products.PrintTemplate`
+- Purpose: Canonical material/size template and production cost basis.
+- Key fields:
+  - `material`, `size`, `production_cost`, `prodigi_sku`, `sku_suffix`
+- Constraints:
+  - Unique together: `(material, size)`
+
+### `checkout.ProductShipping`
+- Purpose: Shipping price matrix by print template + destination + method.
+- Key fields:
+  - `product` (FK to `PrintTemplate`)
+  - `country` (`IE`/`US`)
+  - `method` (`budget`/`standard`/`express`)
+  - `cost`
+- Constraints:
+  - Unique together: `(product, country, method)`
+
+### `checkout.Order`
+- Purpose: Customer order record from Stripe checkout webhook.
+- Key fields:
+  - `order_number` (generated UUID-like string)
+  - `user_profile` (nullable FK)
+  - Shipping/contact fields (`first_name`, `email`, address fields)
+  - `shipping_method`, `delivery_cost`, `order_total`, `total_price`
+  - `stripe_pid`
+  - `personal_terms_version`
+  - `date`
+
+### `checkout.OrderItem`
+- Purpose: Line items in an order.
+- Key fields:
+  - `order` (FK to `Order`)
+  - `quantity`, `item_total`
+  - Generic relation: `content_type`, `object_id`, `product`
+  - `details` (JSON options snapshot)
+
+### `products.ProductReview`
+- Purpose: User review against photo/video/physical variant via GenericFK.
+- Key fields:
+  - Generic relation: `content_type`, `object_id`, `product`
+  - `user`, `rating`, `comment`, `approved`, `admin_reply`, `created_at`
+- Constraints:
+  - Unique together: `(content_type, object_id, user)`
+
+### `products.GalleryAccess`
+- Purpose: Temporary gallery access tokens.
+- Key fields:
+  - `email`, `access_code` (unique), `created_at`, `expires_at`
+
+### `products.LicenseRequest`
+- Purpose: Rights-managed commercial licensing request.
+- Key fields:
+  - Generic relation to asset: `content_type`, `object_id`, `asset`
+  - Client/request scope fields (`client_name`, `company`, `email`, `project_type`, `duration`, etc.)
+  - `reach_caps`, `message`
+  - Lifecycle/status fields (`status`, `created_at`, `updated_at`, `paid_at`, `delivered_at`)
+  - Payment linkage (`stripe_checkout_session_id`, `stripe_payment_intent_id`, `stripe_payment_link`, `stripe_payment_link_id`)
+  - `ai_draft_response`, `quoted_price`
+- Indexes/constraints:
+  - Index on `(content_type, object_id)` (`license_asset_idx`)
+  - Conditional unique constraint for active requests per email+asset (case-insensitive on email)
+
+### `products.LicenceOffer`
+- Purpose: Versioned offer snapshots per license request.
+- Key fields:
+  - UUID primary key
+  - `license_request` FK
+  - `version`, `status`, `scope_snapshot`, `quoted_price`, `currency`
+  - Stripe linkage fields (`stripe_product_id`, `stripe_price_id`, `stripe_payment_link_id`, etc.)
+  - `terms_version`, `master_agreement_version`
+  - `created_by`, `created_at`, `paid_at`, `superseded_at`
+- Constraints:
+  - Unique `(license_request, version)`
+  - Unique `stripe_payment_link_id`
+
+### `products.LicenseRequestAuditLog`
+- Purpose: Append-only audit history for status transitions and notes.
+- Key fields:
+  - `license_request` FK
+  - `from_status`, `to_status`
+  - `changed_by` (nullable user FK)
+  - `note`, `metadata`, `changed_at`
+
+### `products.LicenceDocument`
+- Purpose: Generated licensing PDFs (schedule/certificate).
+- Key fields:
+  - UUID primary key
+  - `license_request` FK
+  - `doc_type`, `file` (private storage), `sha256`, `created_at`
+
+### `products.LicenceDeliveryToken`
+- Purpose: One-time, expiring delivery token for licensed asset download.
+- Key fields:
+  - `token` (UUID unique)
+  - `license_request` FK
+  - `expires_at`, `used_at`, `created_at`
+
+### `products.StripeWebhookEvent`
+- Purpose: Idempotency and processing status log for Stripe webhook events.
+- Key fields:
+  - `stripe_event_id` (unique), `event_type`
+  - `received_at`, `processed_at`
+  - `status` (`PROCESSING`, `SUCCESS`, `FAILED`)
+  - `error_message`
+
+### `blog.BlogPost`
+- Purpose: Blog post content.
+- Key fields:
+  - `title`, `slug` (unique), `author` FK
+  - `featured_image`, `content`, `excerpt`
+  - `status` (draft/published), timestamps
+  - `tags` (Taggit manager), `likes` (M2M to users)
+- Behavior:
+  - Sanitizes `content` and `excerpt` on save.
+
+### `blog.Comment`
+- Purpose: Blog comments tied to posts/users.
+- Key fields:
+  - `post` FK, `user` FK, `content`, `approved`, `created_at`
+- Behavior:
+  - Sanitizes `content` on save.
+
+### `home.Testimonial`
+- Purpose: Display testimonials.
+- Fields:
+  - `name`, `text`, `rating`
+
+### `home.NewsletterSubscriber`
+- Purpose: Newsletter signup storage.
+- Fields:
+  - `email` (unique), `created_at`
+
+## Schema Overview (Simplified)
+```text
+auth.User 1---1 UserProfile
+auth.User 1---* ProductReview
+auth.User 1---* BlogPost
+auth.User *---* BlogPost (likes)
+auth.User 1---* Comment
+
+Photo 1---* ProductVariant
+PrintTemplate 1---* ProductShipping
+
+UserProfile 1---* Order
+Order 1---* OrderItem
+OrderItem *---1 (GenericFK -> Photo | Video | ProductVariant)
+
+LicenseRequest *---1 (GenericFK -> Photo | Video)
+LicenseRequest 1---* LicenceOffer
+LicenseRequest 1---* LicenseRequestAuditLog
+LicenseRequest 1---* LicenceDocument
+LicenseRequest 1---* LicenceDeliveryToken
+
+BlogPost 1---* Comment
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,113 @@
+# Deployment Guide
+
+## Overview
+This project is a Django backend intended to run behind HTTPS with static files served by WhiteNoise and media stored either locally (dev) or on S3-compatible storage (Cloudflare R2 in current settings).
+
+## 1. Required Environment Configuration
+
+At minimum for production startup:
+- `DEBUG=False`
+- `SECRET_KEY=<strong random key>`
+
+Strongly recommended:
+- `ENFORCE_STRONG_SECRET_KEY=True`
+- SSL/cookie/HSTS env values aligned with your domain and proxy setup.
+
+### Core Environment Variables
+Set values for the variables used by settings and integrations:
+
+- App/runtime:
+  - `APP_ENV`, `RENDER_ENVIRONMENT`, `DJANGO_ADMIN_URL`
+- Security:
+  - `SECRET_KEY`, `ENFORCE_STRONG_SECRET_KEY`
+  - `SECURE_SSL_REDIRECT`, `SECURE_HSTS_SECONDS`, `SECURE_HSTS_INCLUDE_SUBDOMAINS`, `SECURE_HSTS_PRELOAD`
+  - `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SESSION_COOKIE_SAMESITE`, `CSRF_COOKIE_SAMESITE`
+- Caching/throttling:
+  - `CACHE_REDIS_URL` or `REDIS_URL`
+  - `REQUIRE_SHARED_THROTTLE_CACHE`
+  - `THROTTLE_FAIL_OPEN`
+- Auth cookie mode (if enabled):
+  - `JWT_USE_HTTPONLY_COOKIES`, `JWT_COOKIE_SECURE`, `JWT_COOKIE_SAMESITE`, `JWT_COOKIE_DOMAIN`
+  - `JWT_COOKIE_CSRF_PROTECTION`, `JWT_CSRF_COOKIE_NAME`, `JWT_CSRF_HEADER_NAME`
+- Storage:
+  - `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`, `R2_ENDPOINT_URL`
+  - `R2_PRIVATE_BUCKET_NAME`, `R2_PRIVATE_ACCESS_KEY_ID`, `R2_PRIVATE_SECRET_ACCESS_KEY`
+  - `R2_CUSTOM_DOMAIN`
+- Email:
+  - `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD`
+- Stripe:
+  - `STRIPE_PUBLIC_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`
+- Prodigi:
+  - `PRODIGI_API_KEY`, `PRODIGI_SANDBOX`, `SITE_URL`
+- Internal worker:
+  - `AI_WORKER_SECRET` (+ optional IP allowlist vars)
+
+If a variable is not set in code defaults and your environment requires it, treat it as `Configuration Required`.
+
+## 2. Database Setup
+
+Current `settings.py` uses SQLite:
+- Engine: `django.db.backends.sqlite3`
+- File: `db.sqlite3`
+
+For production relational DB (e.g., PostgreSQL):
+- `Configuration Required` in `settings.py` to read external DB connection settings.
+- CI already provisions PostgreSQL service, but application runtime config is not switched automatically.
+
+## 3. Redis and Throttling Setup
+
+The app supports a shared Redis cache via Django cache backend:
+- Configure `CACHE_REDIS_URL` (or `REDIS_URL`).
+- Set `REQUIRE_SHARED_THROTTLE_CACHE=True` in non-debug environments to prevent accidental local-memory throttling.
+- Throttle state uses cache alias `throttle` (`THROTTLE_CACHE_ALIAS`).
+
+Without Redis:
+- Cache falls back to local-memory backend (per-process counters), unless shared cache is required.
+
+## 4. Celery Setup
+
+Celery tasks/config are not present in this repository.
+- Celery worker/beat deployment is `Configuration Required` if async task queueing is added later.
+- Current async-like workflow for AI drafts uses internal protected HTTP endpoints instead.
+
+## 5. Build and Release Steps
+
+Observed from `build.sh`:
+```bash
+pip install -r requirements.txt
+python manage.py collectstatic --no-input
+python manage.py migrate
+```
+
+Recommended release sequence:
+1. Deploy code + environment variables.
+2. Run `python manage.py check`.
+3. Run `python manage.py migrate --noinput`.
+4. Run `python manage.py collectstatic --no-input`.
+5. Start/restart app process.
+
+## 6. Static and Media Configuration
+
+Static:
+- Served via WhiteNoise.
+- `STATIC_ROOT=staticfiles`.
+
+Media:
+- Debug/test: local filesystem (`MEDIA_ROOT`).
+- Non-debug: S3-compatible storage backend through `django-storages`.
+- Private digital assets use custom `PrivateAssetStorage` and separate private bucket settings.
+
+## 7. Deployment Platform Notes (Render)
+
+This repository is compatible with Render-style deployment (environment-driven settings).
+- Set all production env vars in Render dashboard (not in committed `.env`).
+- Ensure Redis service URL is injected to `CACHE_REDIS_URL`/`REDIS_URL`.
+- Configure HTTPS and trusted host/origin envs for frontend domain(s).
+
+## 8. Post-Deploy Validation Checklist
+- `GET /api/home/testimonials/` returns `200`.
+- Auth login/refresh flow works in your selected mode (header token and/or cookie mode).
+- Throttled public endpoints enforce expected `429` behavior across multiple instances.
+- Stripe webhook endpoint receives signed events successfully.
+- Order flow creates order records and sends confirmation email.
+- License delivery token downloads expire/one-time-use behavior works.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,127 @@
+# Operations Guide
+
+## Runtime Commands
+
+### Start API server
+```bash
+python manage.py runserver
+```
+
+### System checks
+```bash
+python manage.py check
+```
+
+### Apply migrations
+```bash
+python manage.py migrate --noinput
+```
+
+### Run tests
+```bash
+python manage.py test
+```
+
+### Collect static files
+```bash
+python manage.py collectstatic --no-input
+```
+
+## Background Processing
+
+### Celery workers
+Celery is not configured in this repository (`Configuration Required`).
+
+If you add Celery later, document and operate:
+- worker start command
+- beat scheduler command
+- queue names and retry strategy
+
+### Current internal worker pattern
+An internal AI worker can poll/update licensing drafts through protected endpoints:
+- `GET /api/internal/draft-queue/`
+- `POST /api/internal/draft-update/<pk>/`
+
+Operational requirements:
+- Set strong `AI_WORKER_SECRET`.
+- Optionally set `AI_WORKER_IP_ALLOWLIST` and `AI_WORKER_TRUSTED_PROXY_IPS`.
+
+## Failed Job / Failure Handling
+
+No task queue retry store currently exists for API jobs. Failures are handled inline by:
+- Logging exceptions in views/service modules.
+- Persisting Stripe webhook processing status in `StripeWebhookEvent`.
+- Using idempotent Stripe event handling and Prodigi idempotency key based on order number.
+
+Recommended operator checks:
+- Inspect `StripeWebhookEvent` records for `FAILED`.
+- Re-deliver Stripe webhook events from Stripe dashboard when needed.
+- Verify `LicenseRequest` status transitions and audit logs in admin.
+
+## Logging and Monitoring
+
+The code uses Python logging across views/services (`logger = logging.getLogger(__name__)`).
+Logging sink/format/retention is `Configuration Required` (platform-level).
+
+Minimum monitoring targets:
+- 5xx response rates
+- Stripe webhook failure counts
+- Payment intent creation failures
+- Email send failures
+- Throttle backend availability warnings
+
+## Cache/Throttle Operations
+
+- Shared throttling relies on Django cache alias `throttle`.
+- In production, use Redis and set:
+  - `CACHE_REDIS_URL` or `REDIS_URL`
+  - `REQUIRE_SHARED_THROTTLE_CACHE=True`
+- If Redis is unavailable:
+  - behavior depends on `THROTTLE_FAIL_OPEN`:
+    - `True`: allow request and log warning
+    - `False`: return throttled response
+
+## Secret Rotation
+
+Rotate secrets by updating environment variables and restarting processes:
+- `SECRET_KEY` (requires coordinated rollout)
+- Stripe keys/webhook secret
+- SMTP credentials
+- R2 credentials
+- `AI_WORKER_SECRET`
+
+After rotation:
+1. Run `python manage.py check`.
+2. Validate auth, webhook, and storage operations.
+3. Monitor logs for signature/auth failures.
+
+## Migration Operations
+
+For schema updates:
+```bash
+python manage.py makemigrations
+python manage.py migrate --noinput
+```
+
+Operational practice:
+- Take DB backup/snapshot before production migration.
+- Apply migrations once per release.
+- Verify admin/API behavior on changed models.
+
+## Basic Troubleshooting
+
+### `ImproperlyConfigured: Shared throttle cache is required...`
+- Cause: `REQUIRE_SHARED_THROTTLE_CACHE=True` without `CACHE_REDIS_URL`/`REDIS_URL`.
+- Fix: set Redis URL or disable strict requirement in non-production contexts.
+
+### Stripe webhook signature failures
+- Cause: invalid/missing `STRIPE_WEBHOOK_SECRET` or forwarded raw-body issues.
+- Fix: verify webhook secret and ensure raw request body reaches Django unchanged.
+
+### Order created but fulfillment/email failed
+- Cause: downstream provider issue (Prodigi/SMTP).
+- Fix: inspect logs, verify provider credentials and network access, retry manually where appropriate.
+
+### Digital downloads denied unexpectedly
+- Cause: missing purchase linkage or wrong user context.
+- Fix: verify `OrderItem` references and user identity in order history.


### PR DESCRIPTION
## Summary

This PR adds production-grade backend documentation for the Django API repository.  
It expands `README.md` and adds a structured docs set under `docs/` covering architecture, API surface, database models, deployment, and operations.

## Why

We needed accurate backend documentation for deployment readiness, onboarding, and operations handoff, documented only from implemented code paths.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Expanded `README.md` with backend overview, stack, setup, env vars, runtime commands, and deployment references
  - Added `docs/architecture.md`
  - Added `docs/api.md`
  - Added `docs/database.md`
  - Added `docs/deployment.md`
  - Added `docs/operations.md`
- Frontend:
  - N/A
- Infra/Config:
  - Documentation-only (no runtime config changed)

## Testing

- [ ] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [x] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
