### PR TITLE
Add Render frontend origin to trusted lists

### DIFF
--- a/openeire_api/settings.py
+++ b/openeire_api/settings.py
@@ -367,11 +367,9 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 FRONTEND_URL = os.getenv("FRONTEND_URL")
 
-
 def _frontend_origin_from_url(value):
     if not value:
         return None
-
     parsed = urlsplit(str(value).strip())
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ImproperlyConfigured(
@@ -379,12 +377,12 @@ def _frontend_origin_from_url(value):
         )
     return f"{parsed.scheme}://{parsed.netloc}"
 
-
 FRONTEND_ORIGIN = _frontend_origin_from_url(FRONTEND_URL)
 
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
     "http://127.0.0.1:5173",
+    "https://openeire.onrender.com",
 ]
 
 CORS_ALLOW_HEADERS = list(default_headers) + [
@@ -398,9 +396,10 @@ CSRF_TRUSTED_ORIGINS = [
     "http://127.0.0.1:5173",
     "https://openeire.ie",
     "https://openeire.online",
+    "https://openeire.onrender.com",
 ]
 
-if FRONTEND_ORIGIN:
+if FRONTEND_ORIGIN and FRONTEND_ORIGIN not in CORS_ALLOWED_ORIGINS:
     CORS_ALLOWED_ORIGINS.append(FRONTEND_ORIGIN)
     CSRF_TRUSTED_ORIGINS.append(FRONTEND_ORIGIN)
 


### PR DESCRIPTION
## Summary

This PR updates backend origin trust settings for the deployed frontend by adding the Render frontend URL to the CORS and CSRF allowlists. It also avoids duplicating `FRONTEND_ORIGIN` when the same origin is already present in the static configuration.

## Why

The frontend is now being deployed on Render, so the backend needs to explicitly trust that origin for browser requests and CSRF-protected flows. This change ensures hosted cross-origin requests work cleanly while keeping origin handling deterministic.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Added `https://openeire.onrender.com` to `CORS_ALLOWED_ORIGINS`
  - Added `https://openeire.onrender.com` to `CSRF_TRUSTED_ORIGINS`
  - Prevented `FRONTEND_ORIGIN` from being appended twice when already present
- Frontend:
  - N/A in this repo
- Infra/Config:
  - Aligns backend trust settings with the deployed Render frontend origin

## Testing

- [ ] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [x] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
