### PR TITLE
Surface Django request errors in Render logs

### DIFF
--- a/openeire_api/settings.py
+++ b/openeire_api/settings.py
@@ -496,3 +496,32 @@ SOCIALACCOUNT_AUTO_SIGNUP = True
 ACCOUNT_AUTHENTICATION_METHOD = 'email'
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = False
+
+# Send Django request/server errors to the platform logs without enabling DEBUG.
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'render': {
+            'format': '%(asctime)s %(levelname)s %(name)s %(message)s',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'render',
+        },
+    },
+    'loggers': {
+        'django.request': {
+            'handlers': ['console'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+        'django.server': {
+            'handlers': ['console'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+    },
+}


### PR DESCRIPTION
## Summary

This PR adds a production-safe Django logging configuration so request/server errors appear in Render logs without requiring `DEBUG=True`.

## Why

We need visibility into 500-level failures in production, but enabling Django debug mode in production is not acceptable. This change routes Django request errors to standard console output so Render captures them in its logs.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Added `LOGGING` configuration in `openeire_api/settings.py`
  - Sends `django.request` and `django.server` errors to console
  - Added a simple timestamped formatter for platform log readability
- Frontend:
  - N/A
- Infra/Config:
  - No new environment variables required
  - Intended for hosted/runtime log visibility on Render

## Testing

- [x] Django tests/checks pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [x] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
