### PR TITLE
Add new domain to allowed hosts

### DIFF
--- a/openeire_api/settings.py
+++ b/openeire_api/settings.py
@@ -65,6 +65,8 @@ R2_PRIVATE_SECRET_ACCESS_KEY = os.getenv('R2_PRIVATE_SECRET_ACCESS_KEY', R2_SECR
 ALLOWED_HOSTS = [
     "127.0.0.1",
     "localhost",
+    "api.openeire.ie",
+    "api.openeire.online",
 ]
 
 RENDER_EXTERNAL_HOSTNAME = os.getenv('RENDER_EXTERNAL_HOSTNAME')


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the `ALLOWED_HOSTS` configuration in `openeire_api/settings.py`, adding two new domains to the list of permitted hosts for the application. 

## Why

* Added `"api.openeire.ie"` and `"api.openeire.online"` to the `ALLOWED_HOSTS` list to allow the application to serve requests from these domains.

## Screenshots / Demo

- [ x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - `settings.py`
- Frontend:
  -
- Infra/Config:
  -

## Testing

- [ x] Django tests pass locally
- [ ] React build passes locally
- [ ] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ x] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [ x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x ] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [ ] Maintainability (naming, structure, duplicated logic)
