### PR TITLE
Enforce account email for authenticated purchases

### DIFF
--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -746,6 +746,27 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
         self.assertEqual(order.user_profile.user_id, self.user.id)
 
     @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_webhook_falls_back_to_stripe_email_when_account_email_blank(self, mock_construct):
+        self.user.email = ""
+        self.user.save(update_fields=["email"])
+        event = self._payment_intent_event()
+        event["data"]["object"]["receipt_email"] = "different@example.com"
+        mock_construct.return_value = event
+
+        response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        order = Order.objects.get()
+        self.assertEqual(order.email, "different@example.com")
+        self.assertIsNotNone(order.user_profile)
+        self.assertEqual(order.user_profile.user_id, self.user.id)
+
+    @patch("checkout.views.stripe.Webhook.construct_event")
     def test_webhook_rejects_digital_order_when_user_id_missing_even_if_username_exists(self, mock_construct):
         mock_construct.return_value = self._payment_intent_event(
             username=self.user.username,
@@ -1254,6 +1275,34 @@ class CreatePaymentIntentSecurityTests(TestCase):
             mock_create.call_args.kwargs["receipt_email"],
             self.user.email,
         )
+
+    @patch("checkout.views.stripe.PaymentIntent.create")
+    def test_authenticated_checkout_requires_valid_account_email(self, mock_create):
+        self.user.email = ""
+        self.user.save(update_fields=["email"])
+        self.client.force_authenticate(user=self.user)
+        payload = {
+            "cart": [
+                {
+                    "product_id": self.photo.id,
+                    "product_type": "photo",
+                    "quantity": 1,
+                    "options": {"license": "hd"},
+                }
+            ],
+            "shipping_details": {"email": "different@example.com"},
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["code"], "ACCOUNT_EMAIL_REQUIRED")
+        self.assertIn("valid email address", response.data["error"])
+        mock_create.assert_not_called()
 
     @patch("checkout.views.stripe.PaymentIntent.create")
     def test_invalid_us_address_for_physical_item_is_rejected(self, mock_create):

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -4,7 +4,8 @@ import logging
 from datetime import timedelta
 from django.conf import settings
 from django.core.mail import EmailMessage
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError as DjangoValidationError
+from django.core.validators import validate_email
 from django.db import transaction
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -40,6 +41,17 @@ from .prodigi import create_prodigi_order
 # Set the Stripe secret key
 stripe.api_key = settings.STRIPE_SECRET_KEY
 logger = logging.getLogger(__name__)
+
+
+def _validated_email_or_none(value):
+    candidate = str(value or "").strip()
+    if not candidate:
+        return None
+    try:
+        validate_email(candidate)
+    except DjangoValidationError:
+        return None
+    return candidate.lower()
 
 class CreatePaymentIntentView(APIView):
     permission_classes = [AllowAny]
@@ -224,7 +236,15 @@ class CreatePaymentIntentView(APIView):
 
         customer_email = None
         if request.user.is_authenticated:
-            customer_email = request.user.email
+            customer_email = _validated_email_or_none(request.user.email)
+            if not customer_email:
+                return Response(
+                    {
+                        "code": "ACCOUNT_EMAIL_REQUIRED",
+                        "error": "Add a valid email address to your account before checkout.",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
         elif isinstance(shipping_details, dict):
             customer_email = shipping_details.get('email')
 
@@ -602,7 +622,16 @@ class StripeWebhookView(APIView):
 
                 if profile is not None:
                     order_data['user_profile'] = profile.id
-                    order_data['email'] = profile.user.email
+                    account_email = _validated_email_or_none(profile.user.email)
+                    if account_email:
+                        order_data['email'] = account_email
+                    else:
+                        logger.warning(
+                            "Authenticated webhook order kept Stripe email because account email was blank or invalid. "
+                            "user_id=%s event_id=%s",
+                            profile.user_id,
+                            event_id,
+                        )
 
                     if save_info:
                         profile.default_phone_number = shipping_details.get('phone', profile.default_phone_number)

--- a/products/serializers.py
+++ b/products/serializers.py
@@ -1,5 +1,7 @@
 import re
 from rest_framework import serializers
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import validate_email
 from .models import (
     Photo,
     Video,
@@ -190,7 +192,18 @@ class LicenseRequestSerializer(serializers.ModelSerializer):
 
         request = self.context.get("request")
         if request is not None and getattr(request, "user", None) and request.user.is_authenticated:
-            data['email'] = request.user.email
+            account_email = str(request.user.email or "").strip().lower()
+            if not account_email:
+                raise serializers.ValidationError(
+                    {"email": "Add a valid email address to your account before submitting a license request."}
+                )
+            try:
+                validate_email(account_email)
+            except DjangoValidationError:
+                raise serializers.ValidationError(
+                    {"email": "Add a valid email address to your account before submitting a license request."}
+                )
+            data['email'] = account_email
 
         try:
             content_type = ContentType.objects.get(app_label='products', model=asset_type)

--- a/products/tests.py
+++ b/products/tests.py
@@ -385,6 +385,27 @@ class LicenseRequestTests(APITestCase):
         obj = LicenseRequest.objects.latest("id")
         self.assertEqual(obj.email, user.email)
 
+    def test_license_request_authenticated_user_requires_valid_account_email(self):
+        user = User.objects.create_user(
+            username="licensedbuyerblank",
+            email="account@example.com",
+            password="StrongPass123!",
+        )
+        user.email = ""
+        user.save(update_fields=["email"])
+        self.client.force_authenticate(user=user)
+        payload = self._payload()
+        payload["email"] = "different@example.com"
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data["email"][0],
+            "Add a valid email address to your account before submitting a license request.",
+        )
+        self.assertFalse(LicenseRequest.objects.filter(client_name="Test Client").exists())
+
     def test_status_context_does_not_leak_across_non_status_save(self):
         req = LicenseRequest.objects.create(
             content_type=ContentType.objects.get_for_model(self.photo),


### PR DESCRIPTION
## Summary

This PR enforces account-email consistency for authenticated checkout and licensing flows.

## Why

Authenticated users could previously submit a different email during checkout or commercial licensing. That created confusing order/licensing records, broke order-history expectations, and weakened the link between an account and its purchases.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Use `request.user.email` for authenticated Stripe payment-intent creation
  - Override webhook-created authenticated order emails with the bound account email
  - Force authenticated commercial license requests to use the signed-in account email
  - Added regression tests for authenticated email override behavior in checkout/webhook/licensing flows
- Frontend:
  - N/A in this repo
- Infra/Config:
  - No environment changes

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [x] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
