### PR TITLE
fix(blog): preserve safe Summernote formatting in post content

### DIFF
--- a/blog/sanitization.py
+++ b/blog/sanitization.py
@@ -2,6 +2,7 @@ import re
 from urllib.parse import urlparse
 
 import bleach
+from bleach.css_sanitizer import CSSSanitizer
 from django.conf import settings
 
 
@@ -10,17 +11,23 @@ CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
 
 BLOG_ALLOWED_TAGS = [
     "p",
+    "div",
+    "span",
     "br",
     "strong",
     "em",
     "b",
     "i",
     "u",
+    "s",
+    "sub",
+    "sup",
     "ul",
     "ol",
     "li",
     "blockquote",
     "a",
+    "h1",
     "h2",
     "h3",
     "h4",
@@ -30,13 +37,52 @@ BLOG_ALLOWED_TAGS = [
     "code",
     "pre",
     "img",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
 ]
 
 BLOG_ALLOWED_ATTRIBUTES = {
-    "a": ["href", "title", "rel"],
+    "a": ["href", "title", "rel", "target"],
+    "p": ["style"],
+    "div": ["style"],
+    "span": ["style"],
+    "blockquote": ["style"],
+    "ul": ["style"],
+    "ol": ["style"],
+    "li": ["style"],
+    "h1": ["style"],
+    "h2": ["style"],
+    "h3": ["style"],
+    "h4": ["style"],
+    "h5": ["style"],
+    "h6": ["style"],
+    "table": ["style"],
+    "thead": ["style"],
+    "tbody": ["style"],
+    "tr": ["style"],
+    "th": ["style", "colspan", "rowspan"],
+    "td": ["style", "colspan", "rowspan"],
+    "pre": ["style"],
+    "code": ["style"],
 }
 
 BLOG_ALLOWED_PROTOCOLS = ["http", "https", "mailto"]
+BLOG_ALLOWED_CSS_PROPERTIES = [
+    "text-align",
+    "color",
+    "background-color",
+    "font-weight",
+    "font-style",
+    "text-decoration",
+    "margin-left",
+    "list-style-type",
+    "width",
+    "height",
+]
 
 
 def _strip_script_style_blocks(text):
@@ -102,11 +148,15 @@ def sanitize_blog_html(value):
     text = _strip_script_style_blocks(str(value))
     attributes = dict(BLOG_ALLOWED_ATTRIBUTES)
     attributes["img"] = _img_attribute_filter
+    css_sanitizer = CSSSanitizer(
+        allowed_css_properties=BLOG_ALLOWED_CSS_PROPERTIES
+    )
     cleaned = bleach.clean(
         text,
         tags=BLOG_ALLOWED_TAGS,
         attributes=attributes,
         protocols=BLOG_ALLOWED_PROTOCOLS,
+        css_sanitizer=css_sanitizer,
         strip=True,
         strip_comments=True,
     )

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -78,6 +78,22 @@ class BlogSanitizationTests(APITestCase):
 
         self.assertEqual(post.excerpt, 'Quick summary')
 
+    def test_blog_post_preserves_safe_summernote_rich_text_formatting(self):
+        post = self._create_post(
+            title='Summernote Formatting',
+            content=(
+                '<p style="text-align:center">'
+                '<span style="color:#c98f3f;text-decoration:underline">Styled</span>'
+                '</p>'
+                '<table><tr><td colspan="2">Cell</td></tr></table>'
+            ),
+        )
+
+        self.assertIn('style="text-align:center;"', post.content)
+        self.assertIn('style="color:#c98f3f;text-decoration:underline;"', post.content)
+        self.assertIn('<table>', post.content)
+        self.assertIn('<td colspan="2">Cell</td>', post.content)
+
     def test_blog_post_generates_slug_only_when_blank(self):
         post = self._create_post(
             title='SEO Slug Post',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.11.0
 bleach==6.3.0
+tinycss2==1.4.0
 boto3==1.42.50
 botocore==1.42.50
 certifi==2025.11.12


### PR DESCRIPTION
## Follow-up fix: preserve Summernote formatting safely

This PR also fixes an issue where legitimate Summernote-authored blog formatting was being stripped before reaching the frontend.

### What was happening

Blog content was being sanitized on the backend, but the allowlist was too narrow for common Summernote output. As a result, legitimate formatting such as:

- inline text styling
- text alignment
- richer block structure
- table markup

could be flattened or removed even though the content came from the trusted admin authoring flow.

### Changes

- Backend:
  - Expanded the blog HTML allowlist to support common Summernote markup, including:
    - `div`
    - `span`
    - `h1`
    - `table`
    - `thead`
    - `tbody`
    - `tr`
    - `th`
    - `td`
    - `sub`
    - `sup`
    - `s`
  - Added a constrained CSS sanitizer for a narrow set of safe presentation properties, including:
    - `text-align`
    - `color`
    - `background-color`
    - `font-weight`
    - `font-style`
    - `text-decoration`
    - `margin-left`
    - `list-style-type`
    - `width`
    - `height`
  - Added `tinycss2` to `requirements.txt` for Bleach CSS sanitization support
  - Added regression coverage to verify safe Summernote formatting is preserved
- Security posture:
  - Unsafe tags and behaviors remain blocked, including:
    - `script`
    - dangerous URLs
    - event-handler attributes
    - unsupported embedded content

### Validation

- [x] `python manage.py test blog.tests`
- [x] Existing sanitization protections still preserved
