### PR TITLE
Decode escaped Summernote HTML before sanitizing

### DIFF
--- a/blog/sanitization.py
+++ b/blog/sanitization.py
@@ -1,3 +1,4 @@
+import html
 import re
 from urllib.parse import urlparse
 
@@ -145,7 +146,8 @@ def _img_attribute_filter(tag, name, value):
 def sanitize_blog_html(value):
     if value is None:
         return None
-    text = _strip_script_style_blocks(str(value))
+    text = html.unescape(str(value))
+    text = _strip_script_style_blocks(text)
     attributes = dict(BLOG_ALLOWED_ATTRIBUTES)
     attributes["img"] = _img_attribute_filter
     css_sanitizer = CSSSanitizer(
@@ -166,7 +168,8 @@ def sanitize_blog_html(value):
 def sanitize_blog_plain_text(value, max_len=None):
     if value is None:
         return None
-    text = _strip_script_style_blocks(str(value))
+    text = html.unescape(str(value))
+    text = _strip_script_style_blocks(text)
     cleaned = bleach.clean(
         text,
         tags=[],

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -94,6 +94,16 @@ class BlogSanitizationTests(APITestCase):
         self.assertIn('<table>', post.content)
         self.assertIn('<td colspan="2">Cell</td>', post.content)
 
+    def test_blog_post_decodes_entity_encoded_html_before_sanitizing(self):
+        post = self._create_post(
+            title='Encoded Summernote HTML',
+            content='&lt;p&gt;Encoded paragraph&lt;/p&gt;&lt;h2&gt;Heading&lt;/h2&gt;',
+        )
+
+        self.assertIn('<p>Encoded paragraph</p>', post.content)
+        self.assertIn('<h2>Heading</h2>', post.content)
+        self.assertNotIn('&lt;p&gt;', post.content)
+
     def test_blog_post_generates_slug_only_when_blank(self):
         post = self._create_post(
             title='SEO Slug Post',
@@ -177,6 +187,20 @@ class BlogSanitizationTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['content'], '<p>Visible</p>')
+
+    def test_blog_detail_decodes_legacy_entity_encoded_html_on_read(self):
+        post = self._create_post(
+            title='Legacy Encoded Content Post',
+            content='<p>Initial</p>',
+        )
+        BlogPost.objects.filter(pk=post.pk).update(
+            content='&lt;p&gt;Visible&lt;/p&gt;&lt;h2&gt;Heading&lt;/h2&gt;'
+        )
+
+        response = self.client.get(reverse('blog_post_detail', args=[post.slug]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['content'], '<p>Visible</p><h2>Heading</h2>')
 
     def test_blog_list_sanitizes_legacy_unsanitized_excerpt_on_read(self):
         post = self._create_post(


### PR DESCRIPTION
## Summary

This PR adds backend support for blog SEO metadata and fixes Summernote-authored blog content rendering so rich HTML formatting is preserved safely.

## Why

The React blog detail page needed proper per-post SEO metadata from the backend, and the existing Summernote content pipeline had two content issues that needed to be resolved at the source:

1. blog posts needed editable SEO fields in Django admin and those values needed to be exposed via the blog API
2. some Summernote-authored posts were either:
   - losing legitimate formatting during sanitization
   - or rendering literal escaped tags like `<p>` and `<h2>` on the live site because entity-encoded HTML was not being decoded before sanitization

This PR fixes both while preserving the current Django admin + Summernote authoring model.

## Changes

- Backend:
  - Added SEO fields to `BlogPost`:
    - `meta_title`
    - `meta_description`
    - `canonical_url`
  - Added migration:
    - `blog/migrations/0003_blogpost_seo_fields.py`
  - Updated Django admin:
    - exposed the SEO fields in the blog post form
    - kept `content` on `django-summernote`
    - preserved tag editing by keeping `tags` in the admin field list
  - Updated blog serializers:
    - list serializer now returns SEO metadata
    - detail serializer now returns:
      - `meta_title`
      - `meta_description`
      - `canonical_url`
      - `excerpt`
  - Preserved existing slug behavior:
    - slug is generated from title only when blank
    - existing slugs are not overwritten on update
  - Improved blog HTML sanitization for Summernote content:
    - expanded the allowlist to support common rich-text tags and table markup
    - added constrained CSS sanitization for safe formatting properties
    - decode entity-escaped HTML before sanitization so escaped Summernote markup renders correctly again
    - continue stripping unsafe tags, attributes, and protocols
  - Added dependency:
    - `tinycss2==1.4.0`
    - required by Bleach CSS sanitization
- Frontend:
  - N/A in this repo
- Infra/Config:
  - No new backend env vars

## Summernote / Content Behavior

This PR keeps the existing content model and authoring workflow:

- blog content continues to be authored as HTML in Summernote
- internal links continue to be authored directly inside the `content` field
- no separate `internal_links` model or parsing layer was introduced

Example of a valid internal link in Summernote content:

```html
<p>Read our <a href="/blog/licensing-guide/">licensing guide</a> or <a href="/contact/">contact us</a> for a custom quote.</p>
```

Recommended internal targets:
- `/blog/<slug>/`
- `/licensing/`
- `/contact/`
- `/footage/`

Avoid:
- `/api/...`

## Security Notes

The sanitization path still blocks dangerous content such as:

- `script`
- `iframe`
- `object`
- unsafe protocols like `javascript:`
- event-handler attributes such as `onclick`

At the same time, it now preserves safe Summernote formatting and decodes escaped HTML before sanitizing so legitimate markup can render correctly.

## Testing

- [x] Django system checks pass locally
- [x] Blog tests pass locally

### Manual smoke test checklist (quick)

- [x] Blog posts can be edited in admin with Summernote still attached to `content`
- [x] SEO fields are editable in Django admin
- [x] Tags remain editable in Django admin
- [x] Blog API list includes SEO metadata
- [x] Blog API detail includes SEO metadata and excerpt
- [x] Existing slug behavior is preserved
- [x] Safe Summernote formatting is preserved
- [x] Entity-escaped legacy blog content is decoded and rendered correctly by the API

## Risk & Rollback

Risk level: Medium

Why medium:
- changes persistent blog model schema
- changes the sanitization behavior for blog HTML
- introduces a new backend dependency for CSS sanitization

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described:
  - revert the sanitization expansion if formatting behavior needs to be narrowed again
  - revert the SEO field migration only if the schema change must be rolled back

## Deployment Notes

- Run migrations:
  - `python manage.py migrate`
- Ensure updated dependencies are installed:
  - `pip install -r requirements.txt`

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] additive SEO model change only
- [x] Summernote admin flow remains intact
- [x] tag editing remains available in admin
- [x] serializer output remains backward compatible
- [x] slug generation only occurs when slug is blank
- [x] sanitization preserves safe formatting while still stripping unsafe markup
- [x] entity-escaped Summernote HTML is decoded before sanitization