### PR TITLE
Prefer R2 master keys for video download delivery

### DIFF
--- a/products/models.py
+++ b/products/models.py
@@ -138,13 +138,15 @@ class Video(models.Model):
 
     @property
     def video_asset_name(self):
+        if self.video_file_key:
+            return self.video_file_key
         if self.video_file and self.video_file.name:
             try:
                 if self.video_file.storage.exists(self.video_file.name):
                     return self.video_file.name
             except Exception:
                 return self.video_file.name
-        return self.video_file_key or ""
+        return ""
 
     @property
     def video_asset_filename(self):
@@ -166,14 +168,17 @@ class Video(models.Model):
             return urljoin(f"{media_url.rstrip('/')}/", key.lstrip("/"))
 
     def open_video_asset(self, mode="rb"):
+        if self.video_file_key:
+            try:
+                return PrivateAssetStorage().open(self.video_file_key, mode)
+            except Exception:
+                pass
         if self.video_file and self.video_file.name:
             try:
                 self.video_file.open(mode)
                 return self.video_file
             except Exception:
                 pass
-        if self.video_file_key:
-            return PrivateAssetStorage().open(self.video_file_key, mode)
         return None
 
     def __str__(self):

--- a/products/tests.py
+++ b/products/tests.py
@@ -918,6 +918,52 @@ class LicenseRequestTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("fallback-video.mp4", response["Content-Disposition"])
 
+    def test_secure_video_download_prefers_r2_key_when_both_master_sources_exist(self):
+        user = User.objects.create_user(
+            username="preferredkeybuyer",
+            email="preferredkeybuyer@example.com",
+            password="testpass123",
+        )
+        thumbnail = SimpleUploadedFile("thumb.jpg", b"thumbnail", content_type="image/jpeg")
+        uploaded_video = SimpleUploadedFile(
+            "legacy-upload.mp4",
+            b"legacy-upload-bytes",
+            content_type="video/mp4",
+        )
+        video_key = self._write_private_asset(
+            Path("digital_products/videos/key-preferred-video.mp4"),
+            b"video-bytes-from-r2-key",
+        )
+        video = Video.objects.create(
+            title="Key Preferred Video",
+            description="Uses R2 object key as the authoritative master asset",
+            collection="Test Collection",
+            thumbnail_image=thumbnail,
+            video_file=uploaded_video,
+            video_file_key=video_key,
+            price=Decimal("24.00"),
+            is_active=True,
+        )
+        order = Order.objects.create(
+            user_profile=user.userprofile,
+            email=user.email,
+            stripe_pid="pi_r2_video_download_key_preferred_test",
+        )
+        OrderItem.objects.create(
+            order=order,
+            quantity=1,
+            item_total=Decimal("24.00"),
+            content_type=ContentType.objects.get_for_model(Video),
+            object_id=video.id,
+            details={"license": "hd"},
+        )
+
+        self.client.force_authenticate(user=user)
+        response = self.client.get(reverse("secure-download", args=["video", video.id]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("key-preferred-video.mp4", response["Content-Disposition"])
+
     def test_licence_download_supports_video_r2_object_key(self):
         video_key = self._write_private_asset(
             Path("digital_products/videos/licensed-video.mp4"),


### PR DESCRIPTION
## Summary

This PR fixes paid video delivery so secure download flows prefer the private R2 master asset key over any legacy uploaded file path stored on the `Video` record.

## Why

With the new multipart upload flow, the authoritative paid video master now lives in `video_file_key`.

Some `Video` records can still have both:
- a legacy `video_file`
- a newer `video_file_key`

In that situation, the backend could still try to open the older uploaded file first, which is the wrong source of truth for the current R2-backed workflow and could lead to failed paid downloads even when the correct private master exists in R2.

This issue affects both:
- personal download links sent by email
- in-account secure download buttons

## Changes

- Backend:
  - Updated `Video.video_asset_name` to prefer `video_file_key` when present
  - Updated `Video.open_video_asset()` to open `video_file_key` first and only fall back to `video_file` if no key-backed asset is available
  - Added regression coverage proving secure download prefers the R2 key when both sources exist
- Frontend:
  - N/A in this repo
- Infra/Config:
  - No environment changes

## Result

Paid video delivery now aligns with the new upload model:

- private R2 master key is treated as authoritative
- legacy uploaded file paths are only fallback behavior
- secure delivery is more reliable for mixed/migrated `Video` records

## Testing

- [x] `python manage.py test products.tests`

### Manual smoke test checklist (quick)

- [x] Secure download works for videos backed only by `video_file_key`
- [x] Secure download still works when `video_file` is stale but `video_file_key` is valid
- [x] Secure download now prefers `video_file_key` when both sources exist
- [ ] Retest real purchased video after deploy

## Risk & Rollback

Risk level: Low

Why low:
- small, focused change to asset selection order
- no schema change
- behavior now matches the intended R2-backed master-file model

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] `video_file_key` treated as the authoritative paid master source
- [x] fallback to legacy `video_file` preserved when needed
- [x] no change to preview clip behavior
- [x] regression coverage for mixed-source video records
