### PR TITLE
Sync worker draft payloads and send AI drafts verbatim

### DIFF
--- a/products/licensing.py
+++ b/products/licensing.py
@@ -118,18 +118,11 @@ def _draft_text(value):
 
 def _build_negotiation_email_body(license_request):
     draft_text = _draft_text(license_request.ai_draft_response)
-    scope_summary = "\n".join(_scope_summary_lines(license_request))
 
     if draft_text:
-        return (
-            f"Hi {license_request.client_name},\n\n"
-            f"{draft_text}\n\n"
-            "Current Scope Summary:\n"
-            f"{scope_summary}\n\n"
-            "If you would like to proceed or need any refinements, reply to this email.\n\n"
-            "Kind regards,\n"
-            "OpenEire Studios\n"
-        )
+        return draft_text
+
+    scope_summary = "\n".join(_scope_summary_lines(license_request))
 
     return (
         f"Hi {license_request.client_name},\n\n"
@@ -144,12 +137,6 @@ def _build_negotiation_email_body(license_request):
 
 def _build_payment_email_body(license_request, offer):
     draft_text = _draft_text(license_request.ai_payment_draft_response)
-    scope_summary = "\n".join(
-        _scope_summary_lines(
-            license_request,
-            snapshot=(offer.scope_snapshot if offer and offer.scope_snapshot else license_request.agreed_scope_snapshot),
-        )
-    )
     payment_link = (
         offer.stripe_payment_link_url
         if offer and offer.stripe_payment_link_url
@@ -160,12 +147,17 @@ def _build_payment_email_body(license_request, offer):
         raise ValueError("License request does not have a Stripe payment link.")
     if offer and offer.is_expired:
         raise ValueError("The current payment offer has expired. Generate a fresh offer before sending.")
+    if draft_text:
+        return draft_text
+
+    scope_summary = "\n".join(
+        _scope_summary_lines(
+            license_request,
+            snapshot=(offer.scope_snapshot if offer and offer.scope_snapshot else license_request.agreed_scope_snapshot),
+        )
+    )
 
     intro = (
-        f"Hi {license_request.client_name},\n\n"
-        f"{draft_text}\n\n"
-        if draft_text
-        else
         f"Hi {license_request.client_name},\n\n"
         "Your Rights-Managed licence request has been confirmed by our team.\n\n"
     )

--- a/products/licensing.py
+++ b/products/licensing.py
@@ -117,10 +117,11 @@ def _draft_text(value):
 
 
 def _build_negotiation_email_body(license_request):
-    draft_text = _draft_text(license_request.ai_draft_response)
+    raw_draft_text = license_request.ai_draft_response or ""
+    draft_text = _draft_text(raw_draft_text)
 
     if draft_text:
-        return draft_text
+        return raw_draft_text
 
     scope_summary = "\n".join(_scope_summary_lines(license_request))
 
@@ -136,7 +137,8 @@ def _build_negotiation_email_body(license_request):
 
 
 def _build_payment_email_body(license_request, offer):
-    draft_text = _draft_text(license_request.ai_payment_draft_response)
+    raw_draft_text = license_request.ai_payment_draft_response or ""
+    draft_text = _draft_text(raw_draft_text)
     payment_link = (
         offer.stripe_payment_link_url
         if offer and offer.stripe_payment_link_url
@@ -148,7 +150,7 @@ def _build_payment_email_body(license_request, offer):
     if offer and offer.is_expired:
         raise ValueError("The current payment offer has expired. Generate a fresh offer before sending.")
     if draft_text:
-        return draft_text
+        return raw_draft_text
 
     scope_summary = "\n".join(
         _scope_summary_lines(

--- a/products/tests.py
+++ b/products/tests.py
@@ -615,7 +615,7 @@ class LicenseRequestTests(APITestCase):
             client_name="Confirmed Client",
             company="Confirmed Co",
             email="confirmed@example.com",
-            project_type="COMMERCIAL",
+            project_type="OTHER",
             duration="1_YEAR",
             message="Confirmed request",
             status="AWAITING_CLIENT_CONFIRMATION",
@@ -623,14 +623,26 @@ class LicenseRequestTests(APITestCase):
             quoted_price=Decimal("250.00"),
             stripe_payment_link="https://buy.stripe.com/test-link",
             stripe_payment_link_id="plink_confirmed",
+            territory="WORLDWIDE",
+            permitted_media="ALL_MEDIA",
+            exclusivity="FULL",
+            reach_caps="999999",
         )
         offer = LicenceOffer.objects.create(
             license_request=obj,
             version=1,
             status="ACTIVE",
-            scope_snapshot={"quoted_price": "250.00"},
+            scope_snapshot={
+                "project_type_display": "Commercial / Advertising",
+                "permitted_media_display": "Paid Digital Ads",
+                "territory_display": "Ireland Only",
+                "duration_display": "1 Year",
+                "exclusivity_display": "Non-Exclusive",
+                "reach_caps": "50000",
+                "quoted_price": "250.00",
+            },
             quoted_price=Decimal("250.00"),
-            currency="EUR",
+            currency="USD",
             terms_version="RM-1.0",
             stripe_payment_link_id="plink_confirmed",
             stripe_payment_link_url="https://buy.stripe.com/test-link",
@@ -650,7 +662,10 @@ class LicenseRequestTests(APITestCase):
         )
         self.assertIn("agreed_scope_summary", response.data[0])
         self.assertIn("territory: Ireland Only", response.data[0]["agreed_scope_summary"])
+        self.assertTrue(response.data[0]["agreed_scope_summary"].startswith("Commercial / Advertising"))
+        self.assertIn("fee: USD 250.00", response.data[0]["agreed_scope_summary"])
         self.assertEqual(response.data[0]["approved_territory"], "Ireland Only")
+        self.assertEqual(response.data[0]["offer_currency"], "USD")
 
     @override_settings(AI_WORKER_SECRET="testsecret", SECURE_SSL_REDIRECT=False)
     def test_ai_worker_payment_link_draft_update_stores_second_draft(self):
@@ -884,6 +899,30 @@ class LicenseRequestTests(APITestCase):
         self.assertEqual(sent.from_email, "licensing@example.com")
         self.assertEqual(sent.body, draft_body)
         self.assertNotIn("buy.stripe.com", sent.body)
+
+    @override_settings(
+        EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
+        DEFAULT_FROM_EMAIL='studio@example.com',
+        LICENSING_FROM_EMAIL='licensing@example.com',
+    )
+    def test_negotiation_email_preserves_ai_draft_whitespace_exactly(self):
+        draft_body = "\nHi Negotiation Client,\n\nBody line.\n\nKind regards,\nGerard Deely\nLicensing Manager\n"
+        req = LicenseRequest.objects.create(
+            content_type=ContentType.objects.get_for_model(self.photo),
+            object_id=self.photo.id,
+            client_name="Negotiation Client",
+            company="Negotiation Co",
+            email="negotiation-whitespace@example.com",
+            project_type="COMMERCIAL",
+            duration="1_YEAR",
+            message="Need a licence",
+            status="SUBMITTED",
+            ai_draft_response=draft_body,
+        )
+
+        send_licence_negotiation_email(req)
+
+        self.assertEqual(mail.outbox[0].body, draft_body)
 
     @override_settings(
         EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',

--- a/products/tests.py
+++ b/products/tests.py
@@ -648,6 +648,9 @@ class LicenseRequestTests(APITestCase):
             response.data[0]["offer_expires_at"],
             expires_at.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
         )
+        self.assertIn("agreed_scope_summary", response.data[0])
+        self.assertIn("territory: Ireland Only", response.data[0]["agreed_scope_summary"])
+        self.assertEqual(response.data[0]["approved_territory"], "Ireland Only")
 
     @override_settings(AI_WORKER_SECRET="testsecret", SECURE_SSL_REDIRECT=False)
     def test_ai_worker_payment_link_draft_update_stores_second_draft(self):
@@ -846,7 +849,15 @@ class LicenseRequestTests(APITestCase):
         DEFAULT_FROM_EMAIL='studio@example.com',
         LICENSING_FROM_EMAIL='licensing@example.com',
     )
-    def test_negotiation_email_sent_without_stripe_link(self):
+    def test_negotiation_email_sent_uses_verbatim_ai_draft_body(self):
+        draft_body = (
+            "Hi Negotiation Client,\n\n"
+            "Thank you for your follow-up. We can extend the proposed licence to EU territory "
+            "subject to the revised fee outlined below.\n\n"
+            "Kind regards,\n"
+            "Gerard Deely\n"
+            "Licensing Manager"
+        )
         req = LicenseRequest.objects.create(
             content_type=ContentType.objects.get_for_model(self.photo),
             object_id=self.photo.id,
@@ -858,7 +869,7 @@ class LicenseRequestTests(APITestCase):
             message="Need a licence",
             status="SUBMITTED",
             quoted_price=Decimal("250.00"),
-            ai_draft_response="We can offer the requested scope at the quoted fee below.",
+            ai_draft_response=draft_body,
             territory="IRELAND",
             permitted_media="WEB_SOCIAL",
             exclusivity="NON_EXCLUSIVE",
@@ -871,7 +882,7 @@ class LicenseRequestTests(APITestCase):
         sent = mail.outbox[0]
         self.assertEqual(sent.to, ["negotiation@example.com"])
         self.assertEqual(sent.from_email, "licensing@example.com")
-        self.assertIn("EUR 250.00", sent.body)
+        self.assertEqual(sent.body, draft_body)
         self.assertNotIn("buy.stripe.com", sent.body)
 
     @override_settings(
@@ -879,7 +890,17 @@ class LicenseRequestTests(APITestCase):
         DEFAULT_FROM_EMAIL='studio@example.com',
         LICENSING_FROM_EMAIL='licensing@example.com',
     )
-    def test_quote_email_sent_with_payment_link_and_fee(self):
+    def test_quote_email_sent_uses_verbatim_ai_payment_draft_body(self):
+        draft_body = (
+            "Hi Test Client,\n\n"
+            "Thank you for confirming the revised scope for EU paid digital usage. "
+            "The agreed licensing fee is EUR 250.00.\n\n"
+            "Please complete payment using this secure link: https://buy.stripe.com/test-link\n"
+            "This payment link remains valid until 2026-04-25T23:59:59Z.\n\n"
+            "Kind regards,\n"
+            "Gerard Deely\n"
+            "Licensing Manager"
+        )
         req = LicenseRequest.objects.create(
             content_type=ContentType.objects.get_for_model(self.photo),
             object_id=self.photo.id,
@@ -897,7 +918,19 @@ class LicenseRequestTests(APITestCase):
             permitted_media="WEB_SOCIAL",
             exclusivity="NON_EXCLUSIVE",
             reach_caps="NONE",
-            ai_draft_response="Draft reviewed by human.",
+            ai_payment_draft_response=draft_body,
+        )
+        LicenceOffer.objects.create(
+            license_request=req,
+            version=1,
+            status="ACTIVE",
+            scope_snapshot={"quoted_price": "250.00"},
+            quoted_price=Decimal("250.00"),
+            currency="EUR",
+            terms_version="RM-1.0",
+            stripe_payment_link_id="plink_test",
+            stripe_payment_link_url="https://buy.stripe.com/test-link",
+            expires_at=timezone.now() + timedelta(days=7),
         )
 
         send_licence_quote_email(req)
@@ -906,8 +939,7 @@ class LicenseRequestTests(APITestCase):
         sent = mail.outbox[0]
         self.assertEqual(sent.to, ["quote@example.com"])
         self.assertEqual(sent.from_email, "licensing@example.com")
-        self.assertIn("https://buy.stripe.com/test-link", sent.body)
-        self.assertIn("EUR 250.00", sent.body)
+        self.assertEqual(sent.body, draft_body)
 
     @override_settings(
         EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',
@@ -1116,6 +1148,14 @@ class LicenseRequestTests(APITestCase):
         LICENSING_FROM_EMAIL='licensing@example.com',
     )
     def test_send_payment_email_transitions_to_payment_pending(self):
+        draft_body = (
+            "Hi Payment Email Client,\n\n"
+            "Thank you for confirming the agreed scope. The licensing fee is EUR 250.00.\n\n"
+            "Please use this secure payment link to complete payment: https://buy.stripe.com/payment-email\n\n"
+            "Kind regards,\n"
+            "Gerard Deely\n"
+            "Licensing Manager"
+        )
         req = LicenseRequest.objects.create(
             content_type=ContentType.objects.get_for_model(self.photo),
             object_id=self.photo.id,
@@ -1130,7 +1170,7 @@ class LicenseRequestTests(APITestCase):
             client_confirmed_at=timezone.now(),
             stripe_payment_link="https://buy.stripe.com/payment-email",
             stripe_payment_link_id="plink_email",
-            ai_payment_draft_response="Please use the secure link below to complete payment.",
+            ai_payment_draft_response=draft_body,
         )
         LicenceOffer.objects.create(
             license_request=req,
@@ -1151,7 +1191,7 @@ class LicenseRequestTests(APITestCase):
         self.assertIsNotNone(req.payment_email_sent_at)
         self.assertEqual(req.last_payment_email_body, mail.outbox[0].body)
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIn("https://buy.stripe.com/payment-email", mail.outbox[0].body)
+        self.assertEqual(mail.outbox[0].body, draft_body)
 
     @override_settings(
         EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend',

--- a/products/views.py
+++ b/products/views.py
@@ -64,6 +64,29 @@ def _to_iso8601_utc(value):
     return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _agreed_snapshot_for_queue(req, offer=None):
+    if offer and offer.scope_snapshot:
+        return offer.scope_snapshot
+    return req.agreed_scope_snapshot or {}
+
+
+def _build_agreed_scope_summary(snapshot, payload):
+    scope_parts = [
+        payload["project_type"],
+        f"media: {snapshot.get('permitted_media_display') or payload['permitted_media']}",
+        f"territory: {snapshot.get('territory_display') or payload['territory']}",
+        f"duration: {snapshot.get('duration_display') or payload['duration']}",
+        f"exclusivity: {snapshot.get('exclusivity_display') or payload['exclusivity']}",
+    ]
+    reach_caps = snapshot.get('reach_caps') or payload["reach_caps"]
+    if reach_caps and str(reach_caps).strip().lower() != "none":
+        scope_parts.append(f"reach caps: {reach_caps}")
+    quoted_price = snapshot.get('quoted_price') or payload["quoted_price"]
+    if quoted_price:
+        scope_parts.append(f"fee: EUR {quoted_price}")
+    return "; ".join(scope_parts)
+
+
 def _redirect_to_private_asset_if_supported(asset, file_key, filename):
     if not file_key or not asset_file_exists(asset):
         return None
@@ -348,6 +371,7 @@ class AILicenseDraftQueueView(APIView):
         }
         if draft_mode == "payment_link":
             current_offer = offer or get_current_offer(req)
+            agreed_snapshot = _agreed_snapshot_for_queue(req, current_offer)
             payload.update(
                 {
                     "payment_link": (
@@ -360,6 +384,22 @@ class AILicenseDraftQueueView(APIView):
                         _to_iso8601_utc(current_offer.expires_at)
                         if current_offer and current_offer.expires_at
                         else None
+                    ),
+                    "agreed_scope_summary": _build_agreed_scope_summary(agreed_snapshot, payload),
+                    "approved_permitted_media": (
+                        agreed_snapshot.get("permitted_media_display") or payload["permitted_media"]
+                    ),
+                    "approved_territory": (
+                        agreed_snapshot.get("territory_display") or payload["territory"]
+                    ),
+                    "approved_duration": (
+                        agreed_snapshot.get("duration_display") or payload["duration"]
+                    ),
+                    "approved_exclusivity": (
+                        agreed_snapshot.get("exclusivity_display") or payload["exclusivity"]
+                    ),
+                    "approved_reach_caps": (
+                        agreed_snapshot.get("reach_caps") or payload["reach_caps"]
                     ),
                 }
             )

--- a/products/views.py
+++ b/products/views.py
@@ -70,9 +70,11 @@ def _agreed_snapshot_for_queue(req, offer=None):
     return req.agreed_scope_snapshot or {}
 
 
-def _build_agreed_scope_summary(snapshot, payload):
+def _build_agreed_scope_summary(snapshot, payload, currency="EUR"):
+    project_type = snapshot.get("project_type_display") or payload["project_type"]
+    currency = (currency or "EUR").strip() or "EUR"
     scope_parts = [
-        payload["project_type"],
+        project_type,
         f"media: {snapshot.get('permitted_media_display') or payload['permitted_media']}",
         f"territory: {snapshot.get('territory_display') or payload['territory']}",
         f"duration: {snapshot.get('duration_display') or payload['duration']}",
@@ -83,7 +85,7 @@ def _build_agreed_scope_summary(snapshot, payload):
         scope_parts.append(f"reach caps: {reach_caps}")
     quoted_price = snapshot.get('quoted_price') or payload["quoted_price"]
     if quoted_price:
-        scope_parts.append(f"fee: EUR {quoted_price}")
+        scope_parts.append(f"fee: {currency} {quoted_price}")
     return "; ".join(scope_parts)
 
 
@@ -372,6 +374,7 @@ class AILicenseDraftQueueView(APIView):
         if draft_mode == "payment_link":
             current_offer = offer or get_current_offer(req)
             agreed_snapshot = _agreed_snapshot_for_queue(req, current_offer)
+            offer_currency = current_offer.currency if current_offer and current_offer.currency else "EUR"
             payload.update(
                 {
                     "payment_link": (
@@ -380,12 +383,17 @@ class AILicenseDraftQueueView(APIView):
                         else None
                     ),
                     "offer_version": current_offer.version if current_offer else None,
+                    "offer_currency": offer_currency,
                     "offer_expires_at": (
                         _to_iso8601_utc(current_offer.expires_at)
                         if current_offer and current_offer.expires_at
                         else None
                     ),
-                    "agreed_scope_summary": _build_agreed_scope_summary(agreed_snapshot, payload),
+                    "agreed_scope_summary": _build_agreed_scope_summary(
+                        agreed_snapshot,
+                        payload,
+                        currency=offer_currency,
+                    ),
                     "approved_permitted_media": (
                         agreed_snapshot.get("permitted_media_display") or payload["permitted_media"]
                     ),


### PR DESCRIPTION
## Summary

This PR tightens the backend/worker licensing integration by making the backend send AI drafts verbatim and by aligning the `payment_link` draft queue payload with what the local worker actually validates.

## Why

During live workflow testing, two integration issues showed up:
1. the backend was wrapping AI-generated licensing emails even though the worker already generated full email bodies, which caused duplicated greetings/signatures
2. the worker skipped payment drafts because it required an explicit agreed scope summary that the backend queue was not sending

This PR resolves those mismatches.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Updated negotiation and payment email send helpers to send AI drafts verbatim when present
  - Kept backend fallback templates for no-draft cases
  - Preserved payment email safety checks for valid payment link and non-expired offer
  - Extended `payment_link` queue payloads to include:
    - `agreed_scope_summary`
    - approved scope display fields
    - `offer_expires_at`
  - Added regression tests covering verbatim email sending and worker-facing queue payload shape
- Frontend:
  - None
- Infra/Config:
 - None

## Testing

- [ ] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

Targeted automated verification completed:
- `python manage.py test products.tests.LicenseRequestTests.test_negotiation_email_sent_uses_verbatim_ai_draft_body`
- `python manage.py test products.tests.LicenseRequestTests.test_quote_email_sent_uses_verbatim_ai_payment_draft_body`
- `python manage.py test products.tests.LicenseRequestTests.test_send_negotiation_email_stores_last_sent_body`
- `python manage.py test products.tests.LicenseRequestTests.test_send_payment_email_transitions_to_payment_pending`
- `python manage.py test products.tests.LicenseRequestTests.test_ai_worker_queue_exposes_payment_link_draft_mode`
- `python manage.py test products.tests.LicenseRequestTests.test_ai_worker_queue_skips_expired_payment_offer`
- `python manage.py test products.tests.LicenseRequestTests.test_ai_worker_payment_link_draft_update_stores_second_draft`

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described: revert the licensing email helper and draft-queue payload changes to restore the prior backend wrapping / queue contract if needed

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
