### PR TITLE
Fail checkout and delivery closed for launch-critical payment flows

### DIFF
--- a/checkout/admin.py
+++ b/checkout/admin.py
@@ -1,5 +1,8 @@
 from django.contrib import admin
+from django.contrib import messages
+from django.utils import timezone
 from .models import Order, OrderItem, ProductShipping
+from .emails import send_order_confirmation_email
 from openeire_api.admin import custom_admin_site
 
 class OrderItemInline(admin.TabularInline):
@@ -19,18 +22,71 @@ class OrderAdmin(admin.ModelAdmin):
     """
     inlines = (OrderItemInline,)
 
+    actions = ("retry_confirmation_emails",)
+
     # Make all fields read-only in the detail view
     readonly_fields = ('order_number', 'user_profile', 'date', 'delivery_cost',
                        'order_total', 'total_price', 'stripe_pid', 'first_name',
                        'email', 'phone_number', 'country', 'postcode', 'town',
                        'street_address1', 'street_address2', 'county',
-                       'personal_terms_version')
+                       'personal_terms_version', 'confirmation_email_status',
+                       'confirmation_email_sent_at', 'confirmation_email_failed_at',
+                       'confirmation_email_error')
 
     # Configure the list view
-    list_display = ('order_number', 'first_name', 'email', 'order_total', 'date', 'personal_terms_version')
-    list_filter = ('date',)
+    list_display = (
+        'order_number',
+        'first_name',
+        'email',
+        'order_total',
+        'date',
+        'personal_terms_version',
+        'confirmation_email_status',
+        'confirmation_email_sent_at',
+    )
+    list_filter = ('date', 'confirmation_email_status')
     search_fields = ('order_number', 'email', 'first_name')
     ordering = ('-date',)
+
+    @admin.action(description="Retry confirmation emails for selected orders")
+    def retry_confirmation_emails(self, request, queryset):
+        sent_count = 0
+        failed_count = 0
+
+        for order in queryset:
+            try:
+                send_order_confirmation_email(order, request=request)
+                order.confirmation_email_status = 'SENT'
+                order.confirmation_email_sent_at = timezone.now()
+                order.confirmation_email_failed_at = None
+                order.confirmation_email_error = ""
+                sent_count += 1
+            except Exception as exc:
+                order.confirmation_email_status = 'FAILED'
+                order.confirmation_email_failed_at = timezone.now()
+                order.confirmation_email_error = f"{exc.__class__.__name__}: {exc}"
+                failed_count += 1
+            order.save(
+                update_fields=[
+                    'confirmation_email_status',
+                    'confirmation_email_sent_at',
+                    'confirmation_email_failed_at',
+                    'confirmation_email_error',
+                ]
+            )
+
+        if sent_count:
+            self.message_user(
+                request,
+                f"Retried confirmation emails successfully for {sent_count} order(s).",
+                level=messages.SUCCESS,
+            )
+        if failed_count:
+            self.message_user(
+                request,
+                f"Confirmation email retry failed for {failed_count} order(s).",
+                level=messages.ERROR,
+            )
 
 class ProductShippingAdmin(admin.ModelAdmin):
     list_display = ('product', 'country', 'method', 'cost')

--- a/checkout/admin.py
+++ b/checkout/admin.py
@@ -52,8 +52,12 @@ class OrderAdmin(admin.ModelAdmin):
     def retry_confirmation_emails(self, request, queryset):
         sent_count = 0
         failed_count = 0
+        skipped_sent_count = 0
 
         for order in queryset:
+            if order.confirmation_email_status == 'SENT':
+                skipped_sent_count += 1
+                continue
             try:
                 send_order_confirmation_email(order, request=request)
                 order.confirmation_email_status = 'SENT'
@@ -86,6 +90,12 @@ class OrderAdmin(admin.ModelAdmin):
                 request,
                 f"Confirmation email retry failed for {failed_count} order(s).",
                 level=messages.ERROR,
+            )
+        if skipped_sent_count:
+            self.message_user(
+                request,
+                f"Skipped {skipped_sent_count} order(s) already marked as sent.",
+                level=messages.WARNING,
             )
 
 class ProductShippingAdmin(admin.ModelAdmin):

--- a/checkout/emails.py
+++ b/checkout/emails.py
@@ -1,0 +1,71 @@
+from urllib.parse import urljoin
+
+from django.conf import settings
+from django.core.mail import EmailMessage
+from django.template.loader import render_to_string
+from django.urls import reverse
+
+from products.personal_downloads import ensure_personal_download_token
+from products.personal_licence import (
+    get_personal_licence_summary,
+    get_personal_licence_url,
+)
+
+
+def _build_personal_download_url(request, token_obj):
+    path = reverse('personal-asset-download', args=[str(token_obj.token)])
+    base_url = getattr(settings, "PERSONAL_DOWNLOAD_BASE_URL", None)
+    if base_url:
+        return urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+    if request is None:
+        raise RuntimeError(
+            "PERSONAL_DOWNLOAD_BASE_URL must be configured when resending confirmation emails without a request context."
+        )
+    return request.build_absolute_uri(path)
+
+
+def _build_profile_url():
+    frontend_url = getattr(settings, "FRONTEND_URL", None)
+    if frontend_url:
+        return urljoin(str(frontend_url).rstrip("/") + "/", "profile")
+    return None
+
+
+def send_order_confirmation_email(order, request=None):
+    cust_email = order.email
+    personal_download_items = []
+    for item in order.items.all():
+        if item.content_type.model not in {"photo", "video"}:
+            continue
+        token_obj = ensure_personal_download_token(item)
+        personal_download_items.append(
+            {
+                "title": getattr(item.product, "title", f"Digital item {item.object_id}"),
+                "download_url": _build_personal_download_url(request, token_obj),
+            }
+        )
+
+    context = {
+        'order': order,
+        'contact_email': settings.DEFAULT_FROM_EMAIL,
+        'personal_terms_url': get_personal_licence_url(request=request),
+        'personal_terms_summary': get_personal_licence_summary(),
+        'personal_download_items': personal_download_items,
+        'profile_url': _build_profile_url(),
+    }
+    subject = render_to_string(
+        'checkout/confirmation_emails/confirmation_email_subject.txt',
+        context,
+    )
+    body = render_to_string(
+        'checkout/confirmation_emails/confirmation_email_body.txt',
+        context,
+    )
+
+    email = EmailMessage(
+        subject=subject.strip(),
+        body=body,
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=[cust_email],
+    )
+    email.send(fail_silently=False)

--- a/checkout/migrations/0008_order_confirmation_email_fields.py
+++ b/checkout/migrations/0008_order_confirmation_email_fields.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('checkout', '0007_order_prodigi_tracking_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='order',
+            name='confirmation_email_error',
+            field=models.TextField(blank=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='order',
+            name='confirmation_email_failed_at',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='order',
+            name='confirmation_email_sent_at',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='order',
+            name='confirmation_email_status',
+            field=models.CharField(
+                choices=[('PENDING', 'Pending'), ('SENT', 'Sent'), ('FAILED', 'Failed')],
+                default='PENDING',
+                max_length=20,
+            ),
+        ),
+    ]

--- a/checkout/models.py
+++ b/checkout/models.py
@@ -10,6 +10,11 @@ from django.contrib.contenttypes.models import ContentType
 from django_countries.fields import CountryField
 
 class Order(models.Model):
+    CONFIRMATION_EMAIL_STATUS_CHOICES = [
+        ('PENDING', 'Pending'),
+        ('SENT', 'Sent'),
+        ('FAILED', 'Failed'),
+    ]
 
     SHIPPING_METHOD_CHOICES = [
         ('budget', 'Budget'),
@@ -53,6 +58,14 @@ class Order(models.Model):
     prodigi_last_callback_at = models.DateTimeField(null=True, blank=True)
     tracking_email_sent_at = models.DateTimeField(null=True, blank=True)
     tracking_email_signature = models.CharField(max_length=64, null=True, blank=True)
+    confirmation_email_status = models.CharField(
+        max_length=20,
+        choices=CONFIRMATION_EMAIL_STATUS_CHOICES,
+        default='PENDING',
+    )
+    confirmation_email_sent_at = models.DateTimeField(null=True, blank=True)
+    confirmation_email_failed_at = models.DateTimeField(null=True, blank=True)
+    confirmation_email_error = models.TextField(blank=True, default="")
 
     def _generate_order_number(self):
         """

--- a/checkout/prodigi.py
+++ b/checkout/prodigi.py
@@ -1,7 +1,8 @@
 import logging
 import os
+import ipaddress
 from typing import Dict, List, Optional, Tuple
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 import requests
 from django.conf import settings
@@ -12,11 +13,33 @@ logger = logging.getLogger(__name__)
 
 
 def _is_non_public_prodigi_asset_url(url: str) -> bool:
-    normalized = str(url or "").strip().lower()
+    raw_url = str(url or "").strip()
+    if not raw_url:
+        return True
+
+    try:
+        parsed = urlsplit(raw_url)
+    except ValueError:
+        return True
+
+    hostname = str(parsed.hostname or "").strip().lower()
+    if not hostname:
+        return True
+    if hostname == "localhost" or hostname.endswith(".local"):
+        return True
+
+    try:
+        ip_address = ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+
     return (
-        "127.0.0.1" in normalized
-        or "localhost" in normalized
-        or normalized.startswith("http://0.0.0.0")
+        ip_address.is_private
+        or ip_address.is_loopback
+        or ip_address.is_link_local
+        or ip_address.is_multicast
+        or ip_address.is_reserved
+        or ip_address.is_unspecified
     )
 
 

--- a/checkout/prodigi.py
+++ b/checkout/prodigi.py
@@ -5,13 +5,43 @@ from urllib.parse import urljoin
 
 import requests
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 
 logger = logging.getLogger(__name__)
 
 
+def _is_non_public_prodigi_asset_url(url: str) -> bool:
+    normalized = str(url or "").strip().lower()
+    return (
+        "127.0.0.1" in normalized
+        or "localhost" in normalized
+        or normalized.startswith("http://0.0.0.0")
+    )
+
+
+def _parse_prodigi_sandbox(raw_value: Optional[str]) -> bool:
+    normalized = str(raw_value or "").strip().lower()
+    if normalized in {"true", "1", "yes", "on"}:
+        return True
+    if normalized in {"false", "0", "no", "off"}:
+        return False
+    raise ImproperlyConfigured(
+        "PRODIGI_SANDBOX must be explicitly set to true or false."
+    )
+
+
 def _prodigi_base_url() -> str:
-    is_sandbox = os.environ.get("PRODIGI_SANDBOX", "True") == "True"
+    raw_prodigi_sandbox = os.environ.get("PRODIGI_SANDBOX")
+    if raw_prodigi_sandbox is None:
+        if getattr(settings, "DEBUG", False) or getattr(settings, "IS_TEST_ENV", False):
+            is_sandbox = True
+        else:
+            raise ImproperlyConfigured(
+                "PRODIGI_SANDBOX must be set explicitly when DEBUG is False."
+            )
+    else:
+        is_sandbox = _parse_prodigi_sandbox(raw_prodigi_sandbox)
     return "https://api.sandbox.prodigi.com/v4.0/" if is_sandbox else "https://api.prodigi.com/v4.0/"
 
 
@@ -189,15 +219,14 @@ def create_prodigi_order(order):
             try:
                 image_url = _get_prodigi_asset_url(product, site_url=site_url)
 
-                if "127.0.0.1" in image_url or "localhost" in image_url:
+                if _is_non_public_prodigi_asset_url(image_url):
                     logger.warning(
-                        "Prodigi cannot access localhost asset URL; using placeholder image "
+                        "Prodigi cannot access non-public asset URL; rejecting fulfillment "
                         "(order=%s, sku=%s)",
                         order.order_number,
                         product.prodigi_sku,
                     )
-                    # Public placeholder image only for local validation/testing paths.
-                    image_url = "https://images.unsplash.com/photo-1506744626753-1fa28f67c9bf?w=2400&q=80"
+                    raise RuntimeError("Prodigi fulfillment asset URL is not publicly reachable.")
 
                 item_payload = {
                     "sku": product.prodigi_sku,

--- a/checkout/serializers.py
+++ b/checkout/serializers.py
@@ -1,9 +1,11 @@
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.db import transaction
 from rest_framework import serializers
 from .models import Order, OrderItem
 from products.models import Photo, Video, ProductVariant
+from products.file_access import asset_file_exists
 from products.personal_downloads import ensure_personal_download_token
 from products.personal_licence import get_personal_licence_url, get_personal_terms_version
 from django.contrib.contenttypes.models import ContentType
@@ -97,6 +99,10 @@ class OrderSerializer(serializers.ModelSerializer):
                         photo__is_active=True,
                         photo__is_printable=True,
                     )
+                elif product_type_str == 'photo':
+                    product_instance = model_class.objects.get(id=product_id, is_active=True)
+                elif product_type_str == 'video':
+                    product_instance = model_class.objects.get(id=product_id, is_active=True)
                 else:
                     product_instance = model_class.objects.get(id=product_id)
                 
@@ -109,6 +115,14 @@ class OrderSerializer(serializers.ModelSerializer):
                 
                 elif product_type_str in ['photo', 'video']:
                     # Digital items have NO shipping cost and now use one price.
+                    if not asset_file_exists(product_instance):
+                        raise serializers.ValidationError(
+                            {
+                                "items": (
+                                    f"Digital product {product_id} is unavailable for delivery."
+                                )
+                            }
+                        )
                     has_consumer_digital_item = True
                     price = product_instance.price
 
@@ -135,28 +149,29 @@ class OrderSerializer(serializers.ModelSerializer):
                     )
                 continue
 
-        order = Order.objects.create(user_profile=user_profile, **validated_data)
-        OrderItem.objects.bulk_create(
-            [
-                OrderItem(order=order, **item_kwargs)
-                for item_kwargs in order_items_to_create
-            ]
-        )
-
         shipping_quote = calculate_physical_shipping_quote(
             line_items=physical_line_items,
             shipping_country=shipping_country,
             shipping_method=shipping_method,
         )
         calculated_delivery_cost = shipping_quote.delivery_cost
-        
-        # 3. Save the calculated values to the order
-        order.order_total = order_total
-        order.delivery_cost = calculated_delivery_cost # Update the field
-        order.total_price = order.order_total + order.delivery_cost
-        if has_consumer_digital_item:
-            order.personal_terms_version = get_personal_terms_version()
-        order.save()
+
+        with transaction.atomic():
+            order = Order.objects.create(user_profile=user_profile, **validated_data)
+            OrderItem.objects.bulk_create(
+                [
+                    OrderItem(order=order, **item_kwargs)
+                    for item_kwargs in order_items_to_create
+                ]
+            )
+
+            # 3. Save the calculated values to the order
+            order.order_total = order_total
+            order.delivery_cost = calculated_delivery_cost # Update the field
+            order.total_price = order.order_total + order.delivery_cost
+            if has_consumer_digital_item:
+                order.personal_terms_version = get_personal_terms_version()
+            order.save()
 
         return order
 
@@ -193,6 +208,18 @@ class OrderSerializer(serializers.ModelSerializer):
                 if not isinstance(options, dict):
                     raise serializers.ValidationError(
                         {"items": f"Invalid options payload for {p_type} item."}
+                    )
+                product_id = item.get('product_id')
+                model_class = Photo if p_type == 'photo' else Video
+                try:
+                    product = model_class.objects.get(id=product_id, is_active=True)
+                except model_class.DoesNotExist:
+                    raise serializers.ValidationError(
+                        {"items": f"Digital product {product_id} is no longer available for sale."}
+                    )
+                if not asset_file_exists(product):
+                    raise serializers.ValidationError(
+                        {"items": f"Digital product {product_id} is unavailable for delivery."}
                     )
 
         return data

--- a/checkout/shipping.py
+++ b/checkout/shipping.py
@@ -13,6 +13,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_FREE_SHIPPING_THRESHOLD = Decimal("150.00")
 
 
+class ShippingConfigurationError(Exception):
+    """Raised when required physical shipping config is missing."""
+
+
 @dataclass(frozen=True)
 class ShippingQuote:
     delivery_cost: Decimal
@@ -69,6 +73,7 @@ def free_shipping_applies(*, physical_subtotal, shipping_country):
 def calculate_physical_shipping_quote(*, line_items, shipping_country, shipping_method):
     physical_subtotal = Decimal("0.00")
     delivery_cost = Decimal("0.00")
+    missing_shipping_rules = []
 
     for product_instance, quantity in line_items:
         line_quantity = int(quantity or 0)
@@ -97,11 +102,24 @@ def calculate_physical_shipping_quote(*, line_items, shipping_country, shipping_
                 shipping_country,
                 shipping_method,
             )
+            missing_shipping_rules.append(
+                (
+                    product_instance.material,
+                    product_instance.size,
+                    shipping_country,
+                    shipping_method,
+                )
+            )
 
     free_shipping = free_shipping_applies(
         physical_subtotal=physical_subtotal,
         shipping_country=shipping_country,
     )
+    if missing_shipping_rules and not free_shipping:
+        raise ShippingConfigurationError(
+            "Shipping is not available for one or more items in your cart. "
+            "Please contact support before completing checkout."
+        )
     if free_shipping:
         delivery_cost = Decimal("0.00")
 

--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -665,7 +665,7 @@ class StripeWebhookLicenseTests(TestCase):
             HTTP_STRIPE_SIGNATURE="sig",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 500)
         self.license_request.refresh_from_db()
         self.assertEqual(self.license_request.status, "PAYMENT_PENDING")
         self.assertEqual(LicenceDocument.objects.filter(license_request=self.license_request).count(), 0)

--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -36,6 +36,7 @@ from .address_validation import validate_physical_shipping_address
 from .prodigi import (
     _get_prodigi_asset_url,
     _get_prodigi_callback_url,
+    _is_non_public_prodigi_asset_url,
     _prodigi_base_url,
     create_prodigi_order,
 )
@@ -357,6 +358,23 @@ class ProdigiIntegrationSecurityTests(SimpleTestCase):
         self.assertIn(
             "Prodigi cannot access non-public asset URL; rejecting fulfillment",
             " ".join(captured_logs.output),
+        )
+
+    def test_prodigi_rejects_private_and_local_asset_hosts(self):
+        self.assertTrue(
+            _is_non_public_prodigi_asset_url("http://10.0.0.5/media/high-res.jpg")
+        )
+        self.assertTrue(
+            _is_non_public_prodigi_asset_url("https://192.168.1.25/media/high-res.jpg")
+        )
+        self.assertTrue(
+            _is_non_public_prodigi_asset_url("https://[fe80::1]/media/high-res.jpg")
+        )
+        self.assertTrue(
+            _is_non_public_prodigi_asset_url("https://studio-assets.local/media/high-res.jpg")
+        )
+        self.assertFalse(
+            _is_non_public_prodigi_asset_url("https://cdn.example.com/media/high-res.jpg")
         )
 
     def test_prodigi_prefers_storage_signed_url_for_private_assets(self):
@@ -922,6 +940,34 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
         self.assertIsNone(order.confirmation_email_failed_at)
         self.assertEqual(order.confirmation_email_error, "")
         mock_send_confirmation_email.assert_called_once_with(order, request=request)
+
+    @patch("checkout.admin.send_order_confirmation_email", side_effect=RuntimeError("smtp offline"))
+    def test_admin_retry_confirmation_email_skips_orders_already_sent(self, mock_send_confirmation_email):
+        sent_at = timezone.now()
+        order = Order.objects.create(
+            user_profile=self.user.userprofile,
+            email=self.user.email,
+            stripe_pid="pi_confirmation_already_sent",
+            confirmation_email_status="SENT",
+            confirmation_email_sent_at=sent_at,
+        )
+        order_admin = OrderAdmin(Order, custom_admin_site)
+        order_admin.message_user = Mock()
+        request = self.factory.post("/admin/checkout/order/")
+        request.user = get_user_model().objects.create_superuser(
+            username="adminskipretry",
+            email="adminskipretry@example.com",
+            password="StrongPass123!",
+        )
+
+        order_admin.retry_confirmation_emails(request, Order.objects.filter(pk=order.pk))
+
+        order.refresh_from_db()
+        self.assertEqual(order.confirmation_email_status, "SENT")
+        self.assertEqual(order.confirmation_email_sent_at, sent_at)
+        self.assertIsNone(order.confirmation_email_failed_at)
+        self.assertEqual(order.confirmation_email_error, "")
+        mock_send_confirmation_email.assert_not_called()
 
     @patch("checkout.views.stripe.Webhook.construct_event")
     def test_webhook_ignores_invalid_digital_license_option(self, mock_construct):

--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -11,10 +11,11 @@ from unittest.mock import patch, Mock
 
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models.signals import post_save
-from django.test import TestCase, override_settings, SimpleTestCase
+from django.test import TestCase, override_settings, SimpleTestCase, RequestFactory
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
@@ -32,9 +33,18 @@ from products.models import (
 )
 from .models import Order, OrderItem, ProductShipping
 from .address_validation import validate_physical_shipping_address
-from .prodigi import create_prodigi_order, _get_prodigi_asset_url, _get_prodigi_callback_url
+from .prodigi import (
+    _get_prodigi_asset_url,
+    _get_prodigi_callback_url,
+    _prodigi_base_url,
+    create_prodigi_order,
+)
+from .admin import OrderAdmin
 from . import views as checkout_views
 from .serializers import OrderSerializer
+from .shipping import ShippingConfigurationError, calculate_physical_shipping_quote
+from openeire_api.admin import custom_admin_site
+from openeire_api.settings import require_env_in_production
 
 
 class PhysicalAddressValidationTests(SimpleTestCase):
@@ -316,6 +326,39 @@ class ProdigiIntegrationSecurityTests(SimpleTestCase):
         self.assertIn("prepared_items=1", logs)
         self.assertIn("missing_sku=1", logs)
 
+    @patch("checkout.prodigi.requests.post")
+    def test_prodigi_rejects_localhost_asset_urls_instead_of_using_placeholder(self, mock_post):
+        localhost_order = self._build_order()
+        localhost_order.items = self._ItemsManager(
+            [
+                SimpleNamespace(
+                    product=SimpleNamespace(
+                        prodigi_sku="ECO-CAN-12X18",
+                        material="eco_canvas",
+                        photo=SimpleNamespace(
+                            high_res_file=SimpleNamespace(url="http://127.0.0.1:8000/media/high-res.jpg")
+                        ),
+                    ),
+                    quantity=1,
+                )
+            ]
+        )
+
+        with patch.dict(os.environ, {"PRODIGI_API_KEY": "test_key", "PRODIGI_SANDBOX": "True"}, clear=False):
+            with self.assertLogs("checkout.prodigi", level="WARNING") as captured_logs:
+                with self.assertRaises(RuntimeError) as raised:
+                    create_prodigi_order(localhost_order)
+
+        self.assertEqual(
+            str(raised.exception),
+            "Prodigi fulfillment could not prepare all physical items.",
+        )
+        self.assertEqual(mock_post.call_count, 0)
+        self.assertIn(
+            "Prodigi cannot access non-public asset URL; rejecting fulfillment",
+            " ".join(captured_logs.output),
+        )
+
     def test_prodigi_prefers_storage_signed_url_for_private_assets(self):
         signed_url = "https://private-r2.example.com/digital_products/photos/high-res.jpg?X-Amz-Signature=test"
         file_handle = self._StorageBackedFileHandle(
@@ -356,6 +399,26 @@ class ProdigiIntegrationSecurityTests(SimpleTestCase):
     def test_prodigi_callback_url_is_disabled_without_base_url(self):
         self.assertIsNone(_get_prodigi_callback_url())
 
+    @override_settings(DEBUG=True, IS_TEST_ENV=False)
+    def test_prodigi_defaults_to_sandbox_in_debug_when_env_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(
+                _prodigi_base_url(),
+                "https://api.sandbox.prodigi.com/v4.0/",
+            )
+
+    @override_settings(DEBUG=False, IS_TEST_ENV=False)
+    def test_prodigi_requires_explicit_mode_when_debug_is_false(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ImproperlyConfigured):
+                _prodigi_base_url()
+
+    @override_settings(DEBUG=False, IS_TEST_ENV=False)
+    def test_prodigi_rejects_invalid_sandbox_value(self):
+        with patch.dict(os.environ, {"PRODIGI_SANDBOX": "maybe"}, clear=True):
+            with self.assertRaises(ImproperlyConfigured):
+                _prodigi_base_url()
+
     @patch("checkout.prodigi.requests.post")
     def test_prodigi_error_parser_ignores_non_string_fields(self, mock_post):
         mock_response = Mock()
@@ -390,6 +453,27 @@ class ProdigiIntegrationSecurityTests(SimpleTestCase):
         self.assertIn("trace_parent=n/a", log_output)
         self.assertNotIn("ShouldBeIgnored", log_output)
         self.assertNotIn("{'unexpected': 'dict'}", log_output)
+
+
+class ProductionEnvironmentRequirementTests(SimpleTestCase):
+    def test_require_env_in_production_allows_missing_value_in_debug(self):
+        self.assertIsNone(
+            require_env_in_production(
+                "PRODIGI_CALLBACK_BASE_URL",
+                None,
+                debug=True,
+                is_test_env=False,
+            )
+        )
+
+    def test_require_env_in_production_raises_when_missing_in_production(self):
+        with self.assertRaises(ImproperlyConfigured):
+            require_env_in_production(
+                "PRODIGI_CALLBACK_BASE_URL",
+                "",
+                debug=False,
+                is_test_env=False,
+            )
 
 
 @override_settings(
@@ -646,6 +730,7 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
             password="StrongPass123!",
         )
         self.url = reverse("webhook")
+        self.factory = RequestFactory()
 
     def _payment_intent_event(self, license_value="hd", username=None, user_id=None):
         cart = [
@@ -693,6 +778,45 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
             },
         }
 
+    def _physical_payment_intent_event(self, *, event_id="evt_physical_retry", payment_intent_id="pi_physical_retry"):
+        cart = [
+            {
+                "product_id": self.variant.id,
+                "product_type": "physical",
+                "quantity": 1,
+                "options": {},
+            }
+        ]
+        return {
+            "id": event_id,
+            "type": "payment_intent.succeeded",
+            "data": {
+                "object": {
+                    "id": payment_intent_id,
+                    "receipt_email": "buyer@example.com",
+                    "metadata": {
+                        "cart": json.dumps(cart),
+                        "username": "Guest",
+                        "save_info": "false",
+                        "shipping_cost": "8.45",
+                        "shipping_method": "budget",
+                    },
+                    "shipping": {
+                        "name": "Buyer",
+                        "phone": "+3530000000",
+                        "address": {
+                            "country": "IE",
+                            "city": "Galway",
+                            "line1": "1 Test Street",
+                            "line2": "",
+                            "postal_code": "H62 X254",
+                            "state": "Galway",
+                        },
+                    },
+                }
+            },
+        }
+
     @patch("checkout.views.stripe.Webhook.construct_event")
     def test_digital_order_stores_personal_terms_and_includes_it_in_email(self, mock_construct):
         mock_construct.return_value = self._payment_intent_event()
@@ -709,6 +833,9 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
 
         order = Order.objects.first()
         self.assertEqual(order.personal_terms_version, "PERSONAL v1.1 - March 2026")
+        self.assertEqual(order.confirmation_email_status, "SENT")
+        self.assertIsNotNone(order.confirmation_email_sent_at)
+        self.assertFalse(order.confirmation_email_error)
 
         self.assertEqual(len(mail.outbox), 1)
         body = mail.outbox[0].body
@@ -744,6 +871,57 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
         body = mail.outbox[0].body
         self.assertNotIn("None/profile", body)
         self.assertNotIn("logging into your profile", body)
+
+    @patch("checkout.views.send_order_confirmation_email", side_effect=RuntimeError("smtp offline"))
+    @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_confirmation_email_failure_is_recorded_on_order(
+        self,
+        mock_construct,
+        _mock_send_confirmation_email,
+    ):
+        mock_construct.return_value = self._payment_intent_event()
+
+        response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        order = Order.objects.get()
+        self.assertEqual(order.confirmation_email_status, "FAILED")
+        self.assertIsNone(order.confirmation_email_sent_at)
+        self.assertIsNotNone(order.confirmation_email_failed_at)
+        self.assertIn("smtp offline", order.confirmation_email_error)
+
+    @patch("checkout.admin.send_order_confirmation_email")
+    def test_admin_retry_confirmation_email_marks_order_sent(self, mock_send_confirmation_email):
+        order = Order.objects.create(
+            user_profile=self.user.userprofile,
+            email=self.user.email,
+            stripe_pid="pi_confirmation_retry",
+            confirmation_email_status="FAILED",
+            confirmation_email_error="RuntimeError: smtp offline",
+            confirmation_email_failed_at=timezone.now(),
+        )
+        order_admin = OrderAdmin(Order, custom_admin_site)
+        order_admin.message_user = Mock()
+        request = self.factory.post("/admin/checkout/order/")
+        request.user = get_user_model().objects.create_superuser(
+            username="adminretry",
+            email="adminretry@example.com",
+            password="StrongPass123!",
+        )
+
+        order_admin.retry_confirmation_emails(request, Order.objects.filter(pk=order.pk))
+
+        order.refresh_from_db()
+        self.assertEqual(order.confirmation_email_status, "SENT")
+        self.assertIsNotNone(order.confirmation_email_sent_at)
+        self.assertIsNone(order.confirmation_email_failed_at)
+        self.assertEqual(order.confirmation_email_error, "")
+        mock_send_confirmation_email.assert_called_once_with(order, request=request)
 
     @patch("checkout.views.stripe.Webhook.construct_event")
     def test_webhook_ignores_invalid_digital_license_option(self, mock_construct):
@@ -992,43 +1170,10 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
         mock_construct,
         mock_create_prodigi_order,
     ):
-        cart = [
-            {
-                "product_id": self.variant.id,
-                "product_type": "physical",
-                "quantity": 1,
-                "options": {},
-            }
-        ]
-        mock_construct.return_value = {
-            "id": "evt_physical_prodigi_metadata",
-            "type": "payment_intent.succeeded",
-            "data": {
-                "object": {
-                    "id": "pi_physical_prodigi_metadata",
-                    "receipt_email": "buyer@example.com",
-                    "metadata": {
-                        "cart": json.dumps(cart),
-                        "username": "Guest",
-                        "save_info": "false",
-                        "shipping_cost": "8.45",
-                        "shipping_method": "budget",
-                    },
-                    "shipping": {
-                        "name": "Buyer",
-                        "phone": "+3530000000",
-                        "address": {
-                            "country": "IE",
-                            "city": "Galway",
-                            "line1": "1 Test Street",
-                            "line2": "",
-                            "postal_code": "H62 X254",
-                            "state": "Galway",
-                        },
-                    },
-                }
-            },
-        }
+        mock_construct.return_value = self._physical_payment_intent_event(
+            event_id="evt_physical_prodigi_metadata",
+            payment_intent_id="pi_physical_prodigi_metadata",
+        )
         mock_create_prodigi_order.return_value = {
             "order": {
                 "id": "ord_prodigi_123",
@@ -1051,6 +1196,89 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
         self.assertEqual(order.prodigi_status, "InProduction")
         self.assertEqual(order.prodigi_shipments, [])
         self.assertIsNone(order.prodigi_last_callback_at)
+
+    @patch("checkout.views.create_prodigi_order", side_effect=RuntimeError("prodigi offline"))
+    @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_webhook_marks_physical_fulfilment_failure_visible_and_retryable(
+        self,
+        mock_construct,
+        _mock_create_prodigi_order,
+    ):
+        mock_construct.return_value = self._physical_payment_intent_event()
+
+        response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(Order.objects.count(), 1)
+        order = Order.objects.get()
+        self.assertEqual(order.prodigi_status, "FULFILMENT_FAILED")
+        event = StripeWebhookEvent.objects.get(stripe_event_id="evt_physical_retry")
+        self.assertEqual(event.status, "FAILED")
+        self.assertIn(order.order_number, event.error_message)
+        self.assertIn("prodigi offline", event.error_message)
+
+    @patch("checkout.views.create_prodigi_order")
+    @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_webhook_retry_reuses_existing_order_after_prodigi_failure(
+        self,
+        mock_construct,
+        mock_create_prodigi_order,
+    ):
+        mock_construct.return_value = self._physical_payment_intent_event()
+        mock_create_prodigi_order.side_effect = [
+            RuntimeError("prodigi offline"),
+            {
+                "order": {
+                    "id": "ord_prodigi_retry_success",
+                    "status": {"stage": "InProduction"},
+                    "merchantReference": "",
+                    "shipments": [],
+                }
+            },
+        ]
+
+        first_response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+        second_response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(first_response.status_code, 500)
+        self.assertEqual(second_response.status_code, 200)
+        self.assertEqual(Order.objects.count(), 1)
+        order = Order.objects.get()
+        self.assertEqual(order.prodigi_order_id, "ord_prodigi_retry_success")
+        self.assertEqual(order.prodigi_status, "InProduction")
+        event = StripeWebhookEvent.objects.get(stripe_event_id="evt_physical_retry")
+        self.assertEqual(event.status, "SUCCESS")
+        self.assertEqual(mock_create_prodigi_order.call_count, 2)
+
+    @patch("checkout.views.create_prodigi_order")
+    @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_digital_only_webhook_skips_prodigi_fulfilment(self, mock_construct, mock_create_prodigi_order):
+        mock_construct.return_value = self._payment_intent_event()
+
+        response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_create_prodigi_order.assert_not_called()
 
 
 @override_settings(
@@ -1282,6 +1510,59 @@ class CreatePaymentIntentSecurityTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("clientSecret", response.data)
         mock_create.assert_called_once()
+
+    @patch("checkout.views.stripe.PaymentIntent.create")
+    def test_digital_checkout_is_blocked_when_asset_file_is_missing(self, mock_create):
+        self.client.force_authenticate(user=self.user)
+        self.photo.high_res_file.storage.delete(self.photo.high_res_file.name)
+        payload = {
+            "cart": [
+                {
+                    "product_id": self.photo.id,
+                    "product_type": "photo",
+                    "quantity": 1,
+                    "options": {"license": "hd"},
+                }
+            ],
+            "shipping_details": {"email": "buyer@example.com"},
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["code"], "DIGITAL_ASSET_UNAVAILABLE")
+        mock_create.assert_not_called()
+
+    @patch("checkout.views.stripe.PaymentIntent.create")
+    def test_digital_checkout_is_blocked_when_asset_is_inactive(self, mock_create):
+        self.client.force_authenticate(user=self.user)
+        self.photo.is_active = False
+        self.photo.save(update_fields=["is_active"])
+        payload = {
+            "cart": [
+                {
+                    "product_id": self.photo.id,
+                    "product_type": "photo",
+                    "quantity": 1,
+                    "options": {"license": "hd"},
+                }
+            ],
+            "shipping_details": {"email": "buyer@example.com"},
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["code"], "INVALID_CART_PAYLOAD")
+        mock_create.assert_not_called()
 
     @patch("checkout.views.stripe.PaymentIntent.create")
     def test_invalid_options_payload_shape_is_rejected(self, mock_create):
@@ -1653,6 +1934,80 @@ class CreatePaymentIntentSecurityTests(TestCase):
         self.assertEqual(response.data["shippingCost"], 19.76)
         self.assertFalse(response.data["freeShippingApplied"])
 
+    def test_calculate_physical_shipping_quote_returns_expected_cost_when_rule_exists(self):
+        shipping_quote = calculate_physical_shipping_quote(
+            line_items=[(self.variant, 1)],
+            shipping_country="IE",
+            shipping_method="budget",
+        )
+
+        self.assertEqual(shipping_quote.delivery_cost, Decimal("8.45"))
+        self.assertFalse(shipping_quote.free_shipping_applied)
+
+    def test_calculate_physical_shipping_quote_allows_zero_only_for_valid_free_shipping(self):
+        shipping_quote = calculate_physical_shipping_quote(
+            line_items=[(self.variant, 2)],
+            shipping_country="IE",
+            shipping_method="budget",
+        )
+
+        self.assertEqual(shipping_quote.delivery_cost, Decimal("0.00"))
+        self.assertTrue(shipping_quote.free_shipping_applied)
+
+    def test_calculate_physical_shipping_quote_blocks_missing_shipping_rule(self):
+        ProductShipping.objects.filter(
+            product=self.template,
+            country="IE",
+            method="budget",
+        ).delete()
+
+        with self.assertRaises(ShippingConfigurationError):
+            calculate_physical_shipping_quote(
+                line_items=[(self.variant, 1)],
+                shipping_country="IE",
+                shipping_method="budget",
+            )
+
+    @patch("checkout.views.stripe.PaymentIntent.create")
+    def test_physical_cart_cannot_create_payment_intent_when_shipping_rule_missing(self, mock_create):
+        self.photo.is_printable = True
+        self.photo.save(update_fields=["is_printable"])
+        ProductShipping.objects.filter(
+            product=self.template,
+            country="IE",
+            method="budget",
+        ).delete()
+        payload = {
+            "cart": [
+                {
+                    "product_id": self.variant.id,
+                    "product_type": "physical",
+                    "quantity": 1,
+                }
+            ],
+            "shipping_details": {
+                "email": "buyer@example.com",
+                "address": {
+                    "line1": "1 Test Street",
+                    "city": "Dublin",
+                    "country": "IE",
+                    "postal_code": "D01 F5P2",
+                    "state": "Dublin",
+                },
+            },
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["code"], "SHIPPING_UNAVAILABLE")
+        self.assertIn("Shipping is not available", response.data["error"])
+        mock_create.assert_not_called()
+
     @patch("checkout.views.stripe.PaymentIntent.create")
     def test_authenticated_digital_cart_is_allowed(self, mock_create):
         self.client.force_authenticate(user=self.user)
@@ -2001,3 +2356,18 @@ class FreeShippingOrderSerializerTests(TestCase):
         self.assertEqual(order.order_total, Decimal("99.00"))
         self.assertEqual(order.delivery_cost, Decimal("8.45"))
         self.assertEqual(order.total_price, Decimal("107.45"))
+
+    def test_order_serializer_does_not_persist_partial_order_when_shipping_rule_is_missing(self):
+        ProductShipping.objects.filter(
+            product=self.template,
+            country="IE",
+            method="budget",
+        ).delete()
+        serializer = OrderSerializer(data=self._serializer_payload(quantity=1))
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        with self.assertRaises(ShippingConfigurationError):
+            serializer.save()
+
+        self.assertEqual(Order.objects.count(), 0)
+        self.assertEqual(OrderItem.objects.count(), 0)

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -338,7 +338,7 @@ class StripeWebhookView(APIView):
         return "unknown"
 
     def _order_has_physical_items(self, order):
-        return any(item.content_type.model == 'productvariant' for item in order.items.all())
+        return order.items.filter(content_type__model='productvariant').exists()
 
     def _extract_payment_link_id(self, session):
         return session.get('payment_link') or session.get('metadata', {}).get('payment_link_id')

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -4,17 +4,16 @@ import logging
 from datetime import timedelta
 from decimal import Decimal, ROUND_HALF_UP
 from django.conf import settings
-from django.core.mail import EmailMessage
 from django.core.exceptions import ObjectDoesNotExist, ValidationError as DjangoValidationError
 from django.core.validators import validate_email
 from django.db import transaction
-from django.template.loader import render_to_string
 from django.urls import reverse
 from urllib.parse import urljoin
 from django.utils import timezone
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status, generics
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
@@ -31,8 +30,7 @@ from products.licensing import (
     ensure_delivery_token,
     send_licence_delivery_email,
 )
-from products.file_access import get_asset_file_name
-from products.file_access import open_asset_file
+from products.file_access import asset_file_exists, get_asset_file_name, open_asset_file
 from products.personal_downloads import ensure_personal_download_token
 from products.personal_licence import get_personal_licence_summary, get_personal_licence_url
 from userprofiles.models import UserProfile
@@ -41,7 +39,12 @@ from .serializers import OrderSerializer, OrderHistoryListSerializer
 from .address_validation import validate_physical_shipping_address
 from .prodigi import create_prodigi_order, fetch_prodigi_order
 from .order_claiming import claim_guest_orders_for_user
-from .shipping import calculate_physical_shipping_quote, get_free_shipping_threshold
+from .emails import send_order_confirmation_email
+from .shipping import (
+    ShippingConfigurationError,
+    calculate_physical_shipping_quote,
+    get_free_shipping_threshold,
+)
 from .tracking import (
     build_tracking_signature,
     send_tracking_email,
@@ -184,11 +187,23 @@ class CreatePaymentIntentView(APIView):
                         photo__is_active=True,
                         photo__is_printable=True,
                     )
+                elif product_type == 'photo':
+                    product_instance = model_class.objects.get(id=product_id, is_active=True)
+                elif product_type == 'video':
+                    product_instance = model_class.objects.get(id=product_id, is_active=True)
                 else:
                     product_instance = model_class.objects.get(id=product_id)
                 
                 # Digital items use a single price; physical variants use their own price.
                 if product_type in ['photo', 'video']:
+                    if not asset_file_exists(product_instance):
+                        return Response(
+                            {
+                                "code": "DIGITAL_ASSET_UNAVAILABLE",
+                                "error": f"Digital product {product_id} is unavailable for delivery.",
+                            },
+                            status=status.HTTP_400_BAD_REQUEST,
+                        )
                     options = item.get('options') or {}
                     if not isinstance(options, dict):
                         return Response(
@@ -221,11 +236,27 @@ class CreatePaymentIntentView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         
-        shipping_quote = calculate_physical_shipping_quote(
-            line_items=physical_line_items,
-            shipping_country=shipping_country,
-            shipping_method=shipping_method,
-        )
+        try:
+            shipping_quote = calculate_physical_shipping_quote(
+                line_items=physical_line_items,
+                shipping_country=shipping_country,
+                shipping_method=shipping_method,
+            )
+        except ShippingConfigurationError as exc:
+            logger.warning(
+                "CreatePaymentIntentView blocked checkout because shipping configuration was missing "
+                "(country=%s, method=%s, cart_items=%s)",
+                shipping_country,
+                shipping_method,
+                len(physical_line_items),
+            )
+            return Response(
+                {
+                    "code": "SHIPPING_UNAVAILABLE",
+                    "error": str(exc),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         shipping_cost = shipping_quote.delivery_cost
         grand_total = total + shipping_cost
         amount_in_cents = int(
@@ -306,44 +337,8 @@ class StripeWebhookView(APIView):
             return ", ".join(fields) if fields else "unknown"
         return "unknown"
 
-    def _send_confirmation_email(self, order, request=None):
-        """Send the user a confirmation email"""
-        cust_email = order.email
-        personal_download_items = []
-        for item in order.items.all():
-            if item.content_type.model not in {"photo", "video"}:
-                continue
-            token_obj = ensure_personal_download_token(item)
-            personal_download_items.append(
-                {
-                    "title": getattr(item.product, "title", f"Digital item {item.object_id}"),
-                    "download_url": self._build_personal_download_url(request, token_obj),
-                }
-            )
-        context = {
-            'order': order,
-            'contact_email': settings.DEFAULT_FROM_EMAIL,
-            'personal_terms_url': get_personal_licence_url(request=request),
-            'personal_terms_summary': get_personal_licence_summary(),
-            'personal_download_items': personal_download_items,
-            'profile_url': self._build_profile_url(),
-        }
-        subject = render_to_string(
-            'checkout/confirmation_emails/confirmation_email_subject.txt',
-            context,
-        )
-        body = render_to_string(
-            'checkout/confirmation_emails/confirmation_email_body.txt',
-            context,
-        )
-        
-        email = EmailMessage(
-            subject=subject.strip(),
-            body=body,
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            to=[cust_email],
-        )
-        email.send(fail_silently=False)
+    def _order_has_physical_items(self, order):
+        return any(item.content_type.model == 'productvariant' for item in order.items.all())
 
     def _extract_payment_link_id(self, session):
         return session.get('payment_link') or session.get('metadata', {}).get('payment_link_id')
@@ -368,6 +363,32 @@ class StripeWebhookView(APIView):
             return urljoin(str(frontend_url).rstrip("/") + "/", "profile")
         logger.warning("FRONTEND_URL is not configured; omitting profile link from confirmation email")
         return None
+
+    def _mark_confirmation_email_sent(self, order):
+        order.confirmation_email_status = 'SENT'
+        order.confirmation_email_sent_at = timezone.now()
+        order.confirmation_email_failed_at = None
+        order.confirmation_email_error = ""
+        order.save(
+            update_fields=[
+                'confirmation_email_status',
+                'confirmation_email_sent_at',
+                'confirmation_email_failed_at',
+                'confirmation_email_error',
+            ]
+        )
+
+    def _mark_confirmation_email_failed(self, order, exc):
+        order.confirmation_email_status = 'FAILED'
+        order.confirmation_email_failed_at = timezone.now()
+        order.confirmation_email_error = f"{exc.__class__.__name__}: {exc}"
+        order.save(
+            update_fields=[
+                'confirmation_email_status',
+                'confirmation_email_failed_at',
+                'confirmation_email_error',
+            ]
+        )
 
     def _handle_license_payment(self, request, session):
         payment_link_id = self._extract_payment_link_id(session)
@@ -583,6 +604,7 @@ class StripeWebhookView(APIView):
             return Response(status=status.HTTP_200_OK)
 
         processing_error = None
+        retryable_processing_error = False
 
         try:
             if event_type == 'payment_intent.succeeded':
@@ -677,64 +699,83 @@ class StripeWebhookView(APIView):
                         profile.default_country = address_details.get('country', profile.default_country)
                         profile.save()
 
-                # 5. Validate and Save
-                serializer = OrderSerializer(data=order_data)
-                if serializer.is_valid():
-                    order = serializer.save()
-                    logger.info("Order created successfully. order_number=%s", order.order_number)
+                existing_order = Order.objects.filter(
+                    stripe_pid=payment_intent.get('id', '')
+                ).first()
+                order = existing_order
 
+                if order is None:
+                    serializer = OrderSerializer(data=order_data)
+                    if serializer.is_valid():
+                        order = serializer.save()
+                        logger.info("Order created successfully. order_number=%s", order.order_number)
+                    else:
+                        error_fields = self._summarize_validation_errors(serializer.errors)
+                        logger.error("Error creating order. Validation fields: %s", error_fields)
+                        processing_error = f"Order validation failed. Fields: {error_fields}"
+                else:
+                    logger.info(
+                        "Reusing existing order for Stripe retry. order_number=%s stripe_pid=%s",
+                        order.order_number,
+                        order.stripe_pid,
+                    )
+
+                if order and not processing_error:
+                    if order.confirmation_email_status != 'SENT':
+                        try:
+                            send_order_confirmation_email(order, request=request)
+                            self._mark_confirmation_email_sent(order)
+                            logger.info("Confirmation email sent. order_number=%s", order.order_number)
+                        except Exception as exc:
+                            self._mark_confirmation_email_failed(order, exc)
+                            logger.exception(
+                                "Could not send confirmation email. order_number=%s",
+                                order.order_number,
+                            )
                     try:
-                        self._send_confirmation_email(order, request=request)
-                        logger.info("Confirmation email sent. order_number=%s", order.order_number)
-                    except Exception:
-                        logger.exception(
-                            "Could not send confirmation email. order_number=%s",
-                            order.order_number,
-                        )
-                    
-                    try:
-                        has_physical_items = False
-                        for item in order.items.all():
-                            if item.content_type.model == 'productvariant':
-                                has_physical_items = True
-                                break
-                        
-                        if has_physical_items:
-                            # Only contact Prodigi if we actually have prints
-                            logger.info("Sending order to Prodigi. order_number=%s", order.order_number)
-                            prodigi_response = create_prodigi_order(order)
-                            if isinstance(prodigi_response, dict):
-                                prodigi_order = prodigi_response.get("order")
-                                if isinstance(prodigi_order, dict):
-                                    update_order_from_prodigi_payload(order, prodigi_order)
-                            logger.info("Order sent to Prodigi successfully. order_number=%s", order.order_number)
+                        if self._order_has_physical_items(order):
+                            if order.prodigi_order_id:
+                                logger.info(
+                                    "Skipping Prodigi fulfillment because the order already has a Prodigi id. "
+                                    "order_number=%s prodigi_order_id=%s",
+                                    order.order_number,
+                                    order.prodigi_order_id,
+                                )
+                            else:
+                                logger.info("Sending order to Prodigi. order_number=%s", order.order_number)
+                                prodigi_response = create_prodigi_order(order)
+                                if isinstance(prodigi_response, dict):
+                                    prodigi_order = prodigi_response.get("order")
+                                    if isinstance(prodigi_order, dict):
+                                        update_order_from_prodigi_payload(order, prodigi_order)
+                                logger.info("Order sent to Prodigi successfully. order_number=%s", order.order_number)
                         else:
-                            # Digital-only order: Stay silent
                             logger.info(
                                 "Digital-only order detected; skipping Prodigi fulfillment. order_number=%s",
                                 order.order_number,
                             )
-
-                    except Exception:
+                    except Exception as exc:
+                        if order.prodigi_status != "FULFILMENT_FAILED":
+                            order.prodigi_status = "FULFILMENT_FAILED"
+                            order.save(update_fields=["prodigi_status"])
+                        processing_error = (
+                            f"Physical fulfilment failed for order {order.order_number}: {exc}"
+                        )
+                        retryable_processing_error = True
                         logger.exception(
                             "Failed to fulfill order after webhook processing. order_number=%s",
                             order.order_number,
                         )
 
-                else:
-                    error_fields = self._summarize_validation_errors(serializer.errors)
-                    logger.error("Error creating order. Validation fields: %s", error_fields)
-                    processing_error = f"Order validation failed. Fields: {error_fields}"
-                    logger.warning(
-                        "Acknowledging webhook event despite validation failure. %s",
-                        processing_error,
-                    )
-
             elif event_type == 'checkout.session.completed':
                 session = event['data']['object']
                 self._handle_license_payment(request, session)
+        except DRFValidationError as e:
+            processing_error = str(e.detail if hasattr(e, "detail") else e)
+            logger.exception("Validation error processing Stripe event. event_id=%s", event_id)
         except Exception as e:
             processing_error = str(e)
+            retryable_processing_error = True
             logger.exception("Error processing Stripe event. event_id=%s", event_id)
         finally:
             if event_record and should_process_event:
@@ -745,6 +786,9 @@ class StripeWebhookView(APIView):
                     event_type=event_type or 'unknown',
                 )
         
+        if processing_error and retryable_processing_error:
+            return Response(status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
         return Response(status=status.HTTP_200_OK)
 
 class OrderHistoryView(generics.ListAPIView):

--- a/openeire_api/settings.py
+++ b/openeire_api/settings.py
@@ -393,6 +393,14 @@ def _frontend_origin_from_url(value):
 
 FRONTEND_ORIGIN = _frontend_origin_from_url(FRONTEND_URL)
 
+
+def require_env_in_production(name, value, *, debug, is_test_env):
+    if debug or is_test_env:
+        return value
+    if value:
+        return value
+    raise ImproperlyConfigured(f"{name} must be set when DEBUG is False.")
+
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
     "http://127.0.0.1:5173",
@@ -499,6 +507,12 @@ STRIPE_MAX_NETWORK_RETRIES = int(os.getenv('STRIPE_MAX_NETWORK_RETRIES', '2'))
 PRODIGI_CONNECT_TIMEOUT_SECONDS = float(os.getenv('PRODIGI_CONNECT_TIMEOUT_SECONDS', '5'))
 PRODIGI_READ_TIMEOUT_SECONDS = float(os.getenv('PRODIGI_READ_TIMEOUT_SECONDS', '20'))
 PRODIGI_CALLBACK_BASE_URL = os.getenv("PRODIGI_CALLBACK_BASE_URL")
+PRODIGI_CALLBACK_BASE_URL = require_env_in_production(
+    "PRODIGI_CALLBACK_BASE_URL",
+    PRODIGI_CALLBACK_BASE_URL,
+    debug=DEBUG,
+    is_test_env=IS_TEST_ENV,
+)
 FREE_SHIPPING_ENABLED = env_bool(
     os.getenv("FREE_SHIPPING_ENABLED"),
     default=False,
@@ -513,6 +527,18 @@ FREE_SHIPPING_ELIGIBLE_COUNTRIES = [
 STRIPE_PUBLIC_KEY = os.getenv('STRIPE_PUBLIC_KEY')
 STRIPE_SECRET_KEY = os.getenv('STRIPE_SECRET_KEY')
 STRIPE_WEBHOOK_SECRET = os.getenv('STRIPE_WEBHOOK_SECRET')
+require_env_in_production(
+    "STRIPE_SECRET_KEY",
+    STRIPE_SECRET_KEY,
+    debug=DEBUG,
+    is_test_env=IS_TEST_ENV,
+)
+require_env_in_production(
+    "STRIPE_WEBHOOK_SECRET",
+    STRIPE_WEBHOOK_SECRET,
+    debug=DEBUG,
+    is_test_env=IS_TEST_ENV,
+)
 GOOGLE_OAUTH_CLIENT_ID = os.getenv("GOOGLE_OAUTH_CLIENT_ID") or os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_OAUTH_SECRET = os.getenv("GOOGLE_OAUTH_SECRET") or os.getenv("GOOGLE_CLIENT_SECRET")
 GOOGLE_OAUTH_KEY = os.getenv("GOOGLE_OAUTH_KEY", "")

--- a/products/models.py
+++ b/products/models.py
@@ -645,7 +645,7 @@ class PersonalDownloadToken(models.Model):
     @property
     def is_valid(self):
         now = timezone.now()
-        return now < self.expires_at
+        return self.used_at is None and now < self.expires_at
 
     def __str__(self):
         return f"Token for OrderItem {self.order_item_id}"

--- a/products/personal_downloads.py
+++ b/products/personal_downloads.py
@@ -16,6 +16,7 @@ def ensure_personal_download_token(order_item, days=None):
         PersonalDownloadToken.objects.filter(
             order_item=order_item,
             expires_at__gt=now,
+            used_at__isnull=True,
         )
         .order_by("-expires_at")
         .first()

--- a/products/tests.py
+++ b/products/tests.py
@@ -44,6 +44,7 @@ from .licensing import (
     send_licence_negotiation_email,
     send_licence_quote_email,
 )
+from .personal_downloads import ensure_personal_download_token
 from .uploads import build_object_key, sanitize_upload_filename
 
 
@@ -1641,6 +1642,38 @@ class LicenseRequestTests(APITestCase):
         self.assertEqual(response.status_code, 404)
         token.refresh_from_db()
         self.assertIsNone(token.used_at)
+
+    def test_used_personal_download_token_is_not_reused_for_fresh_links(self):
+        user = User.objects.create_user(
+            username="personaltokenfresh",
+            email="personaltokenfresh@example.com",
+            password="testpass123",
+        )
+        order = Order.objects.create(
+            user_profile=user.userprofile,
+            email=user.email,
+            stripe_pid="pi_personal_download_fresh_token",
+            personal_terms_version="PERSONAL v1.1 - March 2026",
+        )
+        order_item = OrderItem.objects.create(
+            order=order,
+            quantity=1,
+            item_total=Decimal("10.00"),
+            content_type=ContentType.objects.get_for_model(Photo),
+            object_id=self.photo.id,
+            details={"license": "hd"},
+        )
+        used_token = PersonalDownloadToken.objects.create(
+            order_item=order_item,
+            expires_at=timezone.now() + timedelta(days=1),
+            used_at=timezone.now(),
+        )
+
+        fresh_token = ensure_personal_download_token(order_item)
+
+        self.assertNotEqual(fresh_token.pk, used_token.pk)
+        self.assertIsNone(fresh_token.used_at)
+        self.assertGreater(fresh_token.expires_at, timezone.now())
 
     @patch("products.views.generate_r2_presigned_url", return_value=None)
     def test_license_delivery_token_is_one_time_for_anonymous_downloads(self, _mock_presigned_url):

--- a/products/tests.py
+++ b/products/tests.py
@@ -1532,7 +1532,7 @@ class LicenseRequestTests(APITestCase):
         self.assertIsNone(token.used_at)
 
     @patch("products.views.generate_r2_presigned_url", return_value=None)
-    def test_personal_download_token_streams_asset_and_remains_valid_until_expiry(self, _mock_presigned_url):
+    def test_personal_download_token_streams_asset_once(self, _mock_presigned_url):
         user = User.objects.create_user(
             username="personaltokendownload",
             email="personaltokendownload@example.com",
@@ -1567,11 +1567,10 @@ class LicenseRequestTests(APITestCase):
 
         second_response = self.client.get(url)
 
-        self.assertEqual(second_response.status_code, 200)
-        self.assertIn("attachment;", second_response["Content-Disposition"])
+        self.assertEqual(second_response.status_code, 404)
 
     @patch("products.views.generate_r2_presigned_url")
-    def test_personal_download_token_redirects_to_presigned_r2_url_until_expiry(
+    def test_personal_download_token_redirects_to_presigned_r2_url_once(
         self, mock_presigned_url
     ):
         mock_presigned_url.return_value = "https://r2.example.com/private-download"
@@ -1610,8 +1609,68 @@ class LicenseRequestTests(APITestCase):
 
         second_response = self.client.get(url)
 
-        self.assertEqual(second_response.status_code, 302)
-        self.assertEqual(second_response["Location"], "https://r2.example.com/private-download")
+        self.assertEqual(second_response.status_code, 404)
+
+    def test_personal_download_token_fails_when_expired(self):
+        user = User.objects.create_user(
+            username="personaltokenexpired",
+            email="personaltokenexpired@example.com",
+            password="testpass123",
+        )
+        order = Order.objects.create(
+            user_profile=user.userprofile,
+            email=user.email,
+            stripe_pid="pi_personal_download_expired",
+            personal_terms_version="PERSONAL v1.1 - March 2026",
+        )
+        order_item = OrderItem.objects.create(
+            order=order,
+            quantity=1,
+            item_total=Decimal("10.00"),
+            content_type=ContentType.objects.get_for_model(Photo),
+            object_id=self.photo.id,
+            details={"license": "hd"},
+        )
+        token = PersonalDownloadToken.objects.create(
+            order_item=order_item,
+            expires_at=timezone.now() - timedelta(minutes=1),
+        )
+
+        response = self.client.get(reverse("personal-asset-download", args=[str(token.token)]))
+
+        self.assertEqual(response.status_code, 404)
+        token.refresh_from_db()
+        self.assertIsNone(token.used_at)
+
+    @patch("products.views.generate_r2_presigned_url", return_value=None)
+    def test_license_delivery_token_is_one_time_for_anonymous_downloads(self, _mock_presigned_url):
+        req = LicenseRequest.objects.create(
+            content_type=ContentType.objects.get_for_model(self.photo),
+            object_id=self.photo.id,
+            client_name="One Time Client",
+            company="Download Co",
+            email="one-time-license@example.com",
+            project_type="COMMERCIAL",
+            duration="1_YEAR",
+            message="Need a licence",
+            status="DELIVERED",
+        )
+        token = LicenceDeliveryToken.objects.create(
+            license_request=req,
+            expires_at=timezone.now() + timedelta(days=1),
+        )
+        url = reverse("license-asset-download", args=[str(token.token)])
+
+        first_response = self.client.get(url)
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertIn("attachment;", first_response["Content-Disposition"])
+        token.refresh_from_db()
+        self.assertIsNotNone(token.used_at)
+
+        second_response = self.client.get(url)
+
+        self.assertEqual(second_response.status_code, 404)
 
     def test_physical_product_page_uses_physical_purchase_flow(self):
         self.photo.is_printable = True

--- a/userprofiles/serializers.py
+++ b/userprofiles/serializers.py
@@ -80,8 +80,8 @@ class UserProfileSerializer(serializers.ModelSerializer):
     is_staff = serializers.BooleanField(source='user.is_staff', read_only=True)
     can_access_gallery = serializers.SerializerMethodField()
     
-    # Use the special serializer field for the country
-    country = CountryField(source='default_country', name_only=True)
+    # Return the ISO country code so frontend selects/prefills work correctly.
+    country = CountryField(source='default_country')
 
     class Meta:
         model = UserProfile

--- a/userprofiles/tests.py
+++ b/userprofiles/tests.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.core import mail
+from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError
 from django.db import transaction
 from django.test import TestCase, override_settings
@@ -7,6 +8,7 @@ from django.urls import reverse
 from allauth.socialaccount.models import SocialApp
 from dj_rest_auth.registration.views import SocialLoginView
 from rest_framework_simplejwt.tokens import AccessToken
+from rest_framework.test import APIClient
 from unittest.mock import patch
 from checkout.models import Order
 
@@ -15,6 +17,7 @@ from .token_utils import (
     PASSWORD_RESET_PURPOSE,
     issue_user_action_token,
 )
+from .views import get_frontend_url
 
 
 @override_settings(
@@ -52,6 +55,97 @@ class PasswordResetRequestTests(TestCase):
             "https://app.openeire.online/password-reset/confirm/",
             mail.outbox[0].body,
         )
+
+
+class FrontendUrlConfigurationTests(TestCase):
+    @override_settings(FRONTEND_URL=None, DEBUG=True, IS_TEST_ENV=False)
+    def test_get_frontend_url_defaults_to_localhost_in_debug(self):
+        self.assertEqual(get_frontend_url(), "http://localhost:5173")
+
+    @override_settings(FRONTEND_URL=None, DEBUG=False, IS_TEST_ENV=False)
+    def test_get_frontend_url_requires_configuration_when_debug_is_false(self):
+        with self.assertRaises(ImproperlyConfigured):
+            get_frontend_url()
+
+
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DEFAULT_FROM_EMAIL="noreply@example.com",
+    FRONTEND_URL="https://app.openeire.online",
+)
+class ChangeEmailTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="changeemailuser",
+            email="old@example.com",
+            password="StrongPass123!",
+            is_active=True,
+        )
+        self.url = reverse("auth_email_change")
+        login_response = self.client.post(
+            reverse("auth_login"),
+            data={"username": self.user.username, "password": "StrongPass123!"},
+        )
+        self.access_token = login_response.json()["access"]
+
+    def test_change_email_updates_email_and_sends_verification(self):
+        response = self.client.put(
+            self.url,
+            data={
+                "new_email": "new@example.com",
+                "current_password": "StrongPass123!",
+            },
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.access_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, "new@example.com")
+        self.assertFalse(self.user.is_active)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("new@example.com", mail.outbox[0].to)
+        self.assertIn("/verify-email/confirm/", mail.outbox[0].body)
+
+    def test_change_email_rejects_wrong_password(self):
+        response = self.client.put(
+            self.url,
+            data={
+                "new_email": "new@example.com",
+                "current_password": "WrongPass123!",
+            },
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.access_token}",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, "old@example.com")
+        self.assertIn("current_password", response.json())
+        self.assertEqual(len(mail.outbox), 0)
+
+
+class UserProfileCountrySerializationTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="countryuser",
+            email="country@example.com",
+            password="StrongPass123!",
+            is_active=True,
+        )
+        self.url = reverse("user_profile")
+
+    def test_profile_returns_country_code_for_frontend_prefill(self):
+        profile = self.user.userprofile
+        profile.default_country = "US"
+        profile.save(update_fields=["default_country"])
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["country"], "US")
 
 
 @override_settings(

--- a/userprofiles/views.py
+++ b/userprofiles/views.py
@@ -1,6 +1,7 @@
 import logging
 import secrets
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from rest_framework import generics, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import AllowAny
@@ -40,7 +41,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_frontend_url():
-    return str(getattr(settings, "FRONTEND_URL", "http://localhost:5173")).rstrip("/")
+    frontend_url = getattr(settings, "FRONTEND_URL", None)
+    if frontend_url:
+        return str(frontend_url).rstrip("/")
+    if getattr(settings, "DEBUG", False) or getattr(settings, "IS_TEST_ENV", False):
+        return "http://localhost:5173"
+    raise ImproperlyConfigured("FRONTEND_URL must be configured when DEBUG is False.")
 
 
 def _token_minutes(setting_name, default_value):
@@ -455,7 +461,7 @@ class ChangeEmailView(generics.UpdateAPIView):
 
     def update(self, request, *args, **kwargs):
         self.object = self.get_object()
-        serializer = self.get_serializer(data=request.data)
+        serializer = self.get_serializer(instance=self.object, data=request.data)
 
         if serializer.is_valid(raise_exception=True):
             # The serializer's .update() method saves the new email and sets user inactive


### PR DESCRIPTION
## Summary

This PR hardens the backend for final launch by closing fail-open paths across checkout, Stripe webhook processing, Prodigi fulfilment, confirmation emails, and digital delivery.

## What changed

### Checkout / order creation
- Blocked digital checkout when an asset is inactive or its private file is not deliverable
- Changed missing physical shipping configuration to fail closed instead of returning zero shipping
- Wrapped order persistence so checkout failures do not leave partial order/item rows behind

### Stripe / webhook handling
- Preserved webhook idempotency by reusing existing orders on Stripe retries
- Marked physical fulfilment failures visibly on the order with `FULFILMENT_FAILED`
- Returned retryable non-2xx responses for retryable fulfilment/runtime failures
- Added visible order-level confirmation email status instead of log-only failure handling

### Confirmation emails
- Added order fields for:
  - `confirmation_email_status`
  - `confirmation_email_sent_at`
  - `confirmation_email_failed_at`
  - `confirmation_email_error`
- Added admin visibility for confirmation email failures
- Added an admin action to retry confirmation emails

### Prodigi hardening
- Made `PRODIGI_SANDBOX` explicit in production/non-debug environments
- Required `PRODIGI_CALLBACK_BASE_URL` in production
- Rejected non-public/localhost Prodigi asset URLs instead of substituting placeholder artwork

### Environment safety
- Required `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` outside debug/test
- Required `FRONTEND_URL` for auth email link generation outside debug/test

### Digital delivery / profile contract
- Made `PersonalDownloadToken` one-time use by requiring `used_at is null`
- Kept `LicenceDeliveryToken` on its existing one-time path
- Returned ISO country codes from profile serialization so checkout/profile prefills work reliably

### Change email
- Fixed `ChangeEmailView` to update the existing user instance instead of falling into serializer create flow

## Why

These changes address launch-critical risks where:
- payment could succeed but fulfilment or delivery could fail silently
- checkout could undercharge due to missing config
- Prodigi could receive the wrong asset
- production could boot with unsafe missing env configuration
- digital delivery links could be reused

## Files of note

- `checkout/views.py`
- `checkout/serializers.py`
- `checkout/shipping.py`
- `checkout/prodigi.py`
- `checkout/emails.py`
- `checkout/admin.py`
- `checkout/models.py`
- `checkout/migrations/0008_order_confirmation_email_fields.py`
- `products/models.py`
- `userprofiles/views.py`
- `userprofiles/serializers.py`
- `openeire_api/settings.py`

## Tests

Added/updated regression coverage for:
- missing shipping rule blocks checkout
- valid free shipping still works correctly
- digital checkout fails when asset file is missing
- Prodigi rejects localhost/non-public asset URLs
- webhook fulfilment failure is visible/retryable
- webhook retry stays idempotent
- confirmation email success/failure state on orders
- admin retry action for failed confirmation emails
- personal download tokens are one-time
- production env requirement helpers
- profile country serialization
- change-email success and wrong-password failure
- frontend URL enforcement outside debug/test

## Operational notes

- Run the new checkout migration before deploy:
  - `checkout/migrations/0008_order_confirmation_email_fields.py`
- Production now requires:
  - `PRODIGI_CALLBACK_BASE_URL`
  - `STRIPE_SECRET_KEY`
  - `STRIPE_WEBHOOK_SECRET`
  - `FRONTEND_URL`

## Verification

- Targeted Django test slices pass for checkout, delivery, and confirmation email state handling
- Frontend build passes against the updated contracts
