### PR TITLE
Fail closed on public recommendations for protected gallery content

### DIFF
--- a/products/tests.py
+++ b/products/tests.py
@@ -441,8 +441,6 @@ class LicenseRequestTests(APITestCase):
             email="approved-recommendations@example.com",
         )
         self._grant_gallery_access(approved_user)
-        approved_user.userprofile.can_access_gallery = True
-        approved_user.userprofile.save(update_fields=["can_access_gallery"])
         digital_photo = self._create_photo(is_active=True)
 
         self.client.force_authenticate(user=approved_user)

--- a/products/tests.py
+++ b/products/tests.py
@@ -86,6 +86,16 @@ class LicenseRequestTests(APITestCase):
             is_printable=is_printable,
         )
 
+    def _create_printable_photo_with_variant(self, *, is_active=True):
+        photo = self._create_photo(is_active=is_active, is_printable=True)
+        ProductVariant.objects.create(
+            photo=photo,
+            material="eco_canvas",
+            size="12x18",
+            price=Decimal("99.00"),
+        )
+        return photo
+
     def _create_video(self, is_active=True):
         thumbnail = SimpleUploadedFile("thumb.jpg", b"thumbnail", content_type="image/jpeg")
         video = SimpleUploadedFile("video.mp4", b"video-bytes", content_type="video/mp4")
@@ -363,10 +373,11 @@ class LicenseRequestTests(APITestCase):
         self.assertEqual(access.granted_user, user)
         self.assertIsNotNone(access.verified_at)
 
-    def test_bag_recommendations_returns_up_to_four_active_photos(self):
+    def test_bag_recommendations_return_only_public_prints_for_unauthorized_users(self):
         for _ in range(5):
-            self._create_photo(is_active=True)
-        inactive = self._create_photo(is_active=False)
+            self._create_printable_photo_with_variant(is_active=True)
+        hidden_digital = self._create_photo(is_active=True)
+        inactive = self._create_printable_photo_with_variant(is_active=False)
 
         url = reverse("bag-recommendations")
         response = self.client.get(url)
@@ -376,8 +387,10 @@ class LicenseRequestTests(APITestCase):
         self.assertLessEqual(len(response.data), 4)
         returned_ids = {item["id"] for item in response.data}
         self.assertNotIn(inactive.id, returned_ids)
+        self.assertNotIn(hidden_digital.id, returned_ids)
+        self.assertTrue(all(item["product_type"] == "physical" for item in response.data))
 
-    def test_bag_recommendations_returns_empty_when_no_active_photos(self):
+    def test_bag_recommendations_returns_empty_when_no_public_prints_exist(self):
         Photo.objects.update(is_active=False)
         url = reverse("bag-recommendations")
         response = self.client.get(url)
@@ -386,8 +399,8 @@ class LicenseRequestTests(APITestCase):
         self.assertEqual(response.data, [])
 
     def test_bag_recommendations_filters_inactive_ids_from_selected_pool(self):
-        active = self._create_photo(is_active=True)
-        inactive = self._create_photo(is_active=False)
+        active = self._create_printable_photo_with_variant(is_active=True)
+        inactive = self._create_printable_photo_with_variant(is_active=False)
         url = reverse("bag-recommendations")
 
         with patch(
@@ -401,15 +414,15 @@ class LicenseRequestTests(APITestCase):
         self.assertIn(active.id, returned_ids)
         self.assertNotIn(inactive.id, returned_ids)
 
-    def test_bag_recommendations_uses_row_offset_sampling_over_active_rows(self):
+    def test_bag_recommendations_uses_row_offset_sampling_over_public_rows(self):
         Photo.objects.update(is_active=False)
-        active_a = self._create_photo(is_active=True)
-        self._create_photo(is_active=False)  # gap
-        active_b = self._create_photo(is_active=True)
-        self._create_photo(is_active=False)  # gap
-        active_c = self._create_photo(is_active=True)
-        active_d = self._create_photo(is_active=True)
-        active_e = self._create_photo(is_active=True)
+        active_a = self._create_printable_photo_with_variant(is_active=True)
+        self._create_printable_photo_with_variant(is_active=False)  # gap
+        active_b = self._create_printable_photo_with_variant(is_active=True)
+        self._create_printable_photo_with_variant(is_active=False)  # gap
+        active_c = self._create_printable_photo_with_variant(is_active=True)
+        active_d = self._create_printable_photo_with_variant(is_active=True)
+        active_e = self._create_printable_photo_with_variant(is_active=True)
         active_ids = [active_a.id, active_b.id, active_c.id, active_d.id, active_e.id]
 
         with patch("products.views.random.randint", return_value=3) as mocked_randint:
@@ -422,6 +435,26 @@ class LicenseRequestTests(APITestCase):
             [item["id"] for item in response.data],
             [active_d.id, active_e.id, active_a.id, active_b.id],
         )
+
+    def test_bag_recommendations_can_return_digital_photos_for_approved_gallery_users(self):
+        approved_user = self._create_gallery_user(
+            email="approved-recommendations@example.com",
+        )
+        self._grant_gallery_access(approved_user)
+        approved_user.userprofile.can_access_gallery = True
+        approved_user.userprofile.save(update_fields=["can_access_gallery"])
+        digital_photo = self._create_photo(is_active=True)
+
+        self.client.force_authenticate(user=approved_user)
+        with patch(
+            "products.views.ShoppingBagRecommendationsView._pick_recommendation_ids",
+            return_value=[digital_photo.id],
+        ):
+            response = self.client.get(reverse("bag-recommendations"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(digital_photo.id, {item["id"] for item in response.data})
+        self.assertTrue(any(item["product_type"] == "photo" for item in response.data))
 
     def test_license_request_message_max_length(self):
         payload = self._payload(message="a" * 3000)

--- a/products/views.py
+++ b/products/views.py
@@ -665,7 +665,19 @@ class ShoppingBagRecommendationsView(APIView):
         return ids
 
     def get(self, request):
-        active_photos = Photo.objects.filter(is_active=True)
+        has_gallery_access = bool(
+            request.user.is_authenticated
+            and getattr(getattr(request.user, "userprofile", None), "can_access_gallery", False)
+        )
+        active_photos = (
+            Photo.objects.filter(is_active=True)
+            if has_gallery_access
+            else Photo.objects.filter(
+                is_active=True,
+                is_printable=True,
+                variants__isnull=False,
+            ).distinct()
+        )
         selected_ids = self._pick_recommendation_ids(active_photos, self.RECOMMENDATION_LIMIT)
 
         if not selected_ids:
@@ -675,14 +687,18 @@ class ShoppingBagRecommendationsView(APIView):
             *[When(id=photo_id, then=position) for position, photo_id in enumerate(selected_ids)],
             output_field=IntegerField(),
         )
-        photos = (
-            Photo.objects
-            .filter(id__in=selected_ids, is_active=True)
-            .annotate(starting_price=Min('variants__price'))
-            .order_by(preserved_order)
-        )
-
-        serializer = PhotoListSerializer(photos, many=True)
+        photos = Photo.objects.filter(id__in=selected_ids, is_active=True)
+        if has_gallery_access:
+            photos = photos.order_by(preserved_order)
+            serializer = PhotoListSerializer(photos, many=True)
+        else:
+            photos = (
+                photos.filter(is_printable=True, variants__isnull=False)
+                .annotate(starting_price=Min('variants__price'))
+                .distinct()
+                .order_by(preserved_order)
+            )
+            serializer = PhysicalPhotoListSerializer(photos, many=True)
         return Response(serializer.data)
 
 

--- a/products/views.py
+++ b/products/views.py
@@ -665,9 +665,9 @@ class ShoppingBagRecommendationsView(APIView):
         return ids
 
     def get(self, request):
+        profile = getattr(request.user, "userprofile", None) if request.user.is_authenticated else None
         has_gallery_access = bool(
-            request.user.is_authenticated
-            and getattr(getattr(request.user, "userprofile", None), "can_access_gallery", False)
+            profile and profile.has_digital_gallery_access
         )
         active_photos = (
             Photo.objects.filter(is_active=True)


### PR DESCRIPTION
## Summary

This PR closes the remaining recommendation leak in the backend by ensuring public bag/recommendation responses do not expose protected digital gallery items.

## What changed

### Recommendation access control
- Updated `ShoppingBagRecommendationsView` to branch on gallery access:
  - unauthorised users only receive active printable photos with physical variants
  - approved gallery users may still receive active digital photo recommendations

### Serialization
- Public/no-access recommendation responses now use the physical serializer path
- Approved users keep the digital/photo serializer path

### Tests
Added/updated regression coverage for:
- unauthorised users only receiving public physical recommendations
- inactive recommendations still being filtered out
- row-offset recommendation sampling still behaving correctly on the public-print pool
- approved gallery users being able to receive digital recommendations

## Files changed

- `products/views.py`
- `products/tests.py`

## Why

Without this change, public recommendation surfaces could expose protected digital products and metadata even when the private digital gallery model was supposed to hide them.

This PR makes recommendations fail closed while preserving the intended experience for approved users.

## Verification

Targeted tests were added around the updated recommendation behavior.

## Manual checks

- Logged-out user: bag/recommendation areas should only show public physical items
- Logged-in user without gallery access: still only public physical items
- Approved gallery user: digital recommendations can still appear
- No protected digital thumbnail/metadata leaks in public recommendation responses
