### PR TITLE
Restrict Stripe checkout to an explicit payment method allowlist

### DIFF
--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -2236,6 +2236,7 @@ class CreatePaymentIntentSecurityTests(TestCase):
         self.assertIn("Shipping is not available", response.data["error"])
         mock_create.assert_not_called()
 
+    @override_settings(STRIPE_PAYMENT_METHOD_TYPES=["card"])
     @patch("checkout.views.stripe.PaymentIntent.create")
     def test_authenticated_digital_cart_is_allowed(self, mock_create):
         self.client.force_authenticate(user=self.user)

--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -2261,6 +2261,40 @@ class CreatePaymentIntentSecurityTests(TestCase):
         mock_create.assert_called_once()
         sent_metadata = mock_create.call_args.kwargs["metadata"]
         self.assertEqual(sent_metadata["user_id"], str(self.user.id))
+        self.assertEqual(
+            mock_create.call_args.kwargs["payment_method_types"],
+            ["card"],
+        )
+        self.assertNotIn("automatic_payment_methods", mock_create.call_args.kwargs)
+
+    @override_settings(STRIPE_PAYMENT_METHOD_TYPES=["card", "klarna"])
+    @patch("checkout.views.stripe.PaymentIntent.create")
+    def test_checkout_uses_configured_payment_method_allowlist(self, mock_create):
+        self.client.force_authenticate(user=self.user)
+        mock_create.return_value = Mock(client_secret="cs_test_123")
+        payload = {
+            "cart": [
+                {
+                    "product_id": self.photo.id,
+                    "product_type": "photo",
+                    "quantity": 1,
+                    "options": {"license": "hd"},
+                }
+            ]
+        }
+
+        response = self.client.post(
+            self.url,
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_create.assert_called_once()
+        self.assertEqual(
+            mock_create.call_args.kwargs["payment_method_types"],
+            ["card", "klarna"],
+        )
 
     @patch("checkout.views.stripe.PaymentIntent.create")
     def test_authenticated_checkout_uses_account_email_over_submitted_email(self, mock_create):

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -68,7 +68,11 @@ def _validated_email_or_none(value):
 def _configured_stripe_payment_method_types():
     configured = getattr(settings, "STRIPE_PAYMENT_METHOD_TYPES", None)
     if isinstance(configured, (list, tuple)):
-        cleaned = [str(value).strip() for value in configured if str(value).strip()]
+        cleaned = [
+            value.strip()
+            for value in configured
+            if isinstance(value, str) and value.strip()
+        ]
         if cleaned:
             return cleaned
     return ["card"]

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -65,6 +65,15 @@ def _validated_email_or_none(value):
         return None
     return candidate.lower()
 
+def _configured_stripe_payment_method_types():
+    configured = getattr(settings, "STRIPE_PAYMENT_METHOD_TYPES", None)
+    if isinstance(configured, (list, tuple)):
+        cleaned = [str(value).strip() for value in configured if str(value).strip()]
+        if cleaned:
+            return cleaned
+    return ["card"]
+
+
 class CreatePaymentIntentView(APIView):
     permission_classes = [AllowAny]
 
@@ -287,7 +296,7 @@ class CreatePaymentIntentView(APIView):
             intent = stripe.PaymentIntent.create(
                 amount=amount_in_cents,
                 currency='eur',
-                automatic_payment_methods={'enabled': True},
+                payment_method_types=_configured_stripe_payment_method_types(),
                 metadata=metadata,
                 receipt_email=customer_email 
             )

--- a/openeire_api/settings.py
+++ b/openeire_api/settings.py
@@ -548,6 +548,17 @@ FREE_SHIPPING_ELIGIBLE_COUNTRIES = [
 STRIPE_PUBLIC_KEY = os.getenv('STRIPE_PUBLIC_KEY')
 STRIPE_SECRET_KEY = os.getenv('STRIPE_SECRET_KEY')
 STRIPE_WEBHOOK_SECRET = os.getenv('STRIPE_WEBHOOK_SECRET')
+
+
+def _stripe_payment_method_types_from_env(raw_value):
+    configured = [value.strip() for value in (raw_value or "").split(",")]
+    return [value for value in configured if value]
+
+
+STRIPE_PAYMENT_METHOD_TYPES = _stripe_payment_method_types_from_env(
+    os.getenv("STRIPE_PAYMENT_METHOD_TYPES", "card")
+)
+
 require_env_in_production(
     "STRIPE_SECRET_KEY",
     STRIPE_SECRET_KEY,


### PR DESCRIPTION
## Summary

This PR simplifies the payment methods shown in Stripe checkout by replacing automatic payment methods with an explicit allowlist.

The default behavior now creates PaymentIntents with `card` only, which removes the extra method clutter such as Revolut Pay, Bancontact, Amazon Pay, and EPS.

## What changed

### Stripe PaymentIntent configuration
- replaced:
  - `automatic_payment_methods={"enabled": True}`
- with:
  - `payment_method_types=[...]`

### New setting
Added:
- `STRIPE_PAYMENT_METHOD_TYPES`

Default:
- `card`

This keeps checkout clean by default while still allowing controlled opt-in to methods like Klarna later.

Example:
```env
STRIPE_PAYMENT_METHOD_TYPES=card,klarna