### PR TITLE
fix(prodigi): relax shipment sync candidate filtering

### DIFF
--- a/checkout/management/commands/sync_prodigi_shipments.py
+++ b/checkout/management/commands/sync_prodigi_shipments.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--debug-candidates",
             action="store_true",
-            help="Print recent order candidate/exclusion reasons before running the sync.",
+            help="Print recent order candidate/exclusion reasons and exit without syncing.",
         )
 
     def handle(self, *args, **options):
@@ -56,6 +56,8 @@ class Command(BaseCommand):
                         prodigi_last_polled_at=row["prodigi_last_polled_at"] or "n/a",
                     )
                 )
+            self.stdout.write("Debug mode only: no Prodigi sync was run.")
+            return
 
         logger.info(
             "Starting scheduled Prodigi shipment sync fallback. candidate_count=%s lookback_days=%s",

--- a/checkout/management/commands/sync_prodigi_shipments.py
+++ b/checkout/management/commands/sync_prodigi_shipments.py
@@ -2,7 +2,11 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from checkout.tracking import get_prodigi_sync_candidates, refresh_order_from_prodigi
+from checkout.tracking import (
+    get_prodigi_sync_candidates,
+    get_prodigi_sync_debug_rows,
+    refresh_order_from_prodigi,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -17,12 +21,41 @@ class Command(BaseCommand):
             default=90,
             help="Look back this many days for candidate Prodigi orders. Defaults to 90.",
         )
+        parser.add_argument(
+            "--debug-candidates",
+            action="store_true",
+            help="Print recent order candidate/exclusion reasons before running the sync.",
+        )
 
     def handle(self, *args, **options):
         lookback_days = max(int(options["days"] or 0), 1)
+        debug_candidates = bool(options.get("debug_candidates"))
         candidates = list(
-            get_prodigi_sync_candidates(lookback_days=lookback_days).order_by("-date")
+            get_prodigi_sync_candidates(lookback_days=lookback_days)
         )
+
+        if debug_candidates:
+            debug_rows = get_prodigi_sync_debug_rows(lookback_days=lookback_days)
+            self.stdout.write(
+                f"Candidate debug for recent orders in the last {lookback_days} day(s):"
+            )
+            if not debug_rows:
+                self.stdout.write("  (no recent orders found)")
+            for row in debug_rows:
+                self.stdout.write(
+                    "  - order_number={order_number} prodigi_order_id={prodigi_order_id} "
+                    "status={prodigi_status} included={included} reasons={reasons} "
+                    "tracking_email_sent_at={tracking_email_sent_at} "
+                    "prodigi_last_polled_at={prodigi_last_polled_at}".format(
+                        order_number=row["order_number"],
+                        prodigi_order_id=row["prodigi_order_id"],
+                        prodigi_status=row["prodigi_status"],
+                        included=str(row["included"]).lower(),
+                        reasons=",".join(row["reasons"]),
+                        tracking_email_sent_at=row["tracking_email_sent_at"] or "n/a",
+                        prodigi_last_polled_at=row["prodigi_last_polled_at"] or "n/a",
+                    )
+                )
 
         logger.info(
             "Starting scheduled Prodigi shipment sync fallback. candidate_count=%s lookback_days=%s",

--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -1672,6 +1672,17 @@ class ProdigiTrackingCallbackTests(TestCase):
 )
 class ProdigiShipmentSyncCommandTests(TestCase):
     def setUp(self):
+        base_media_root = Path(__file__).resolve().parent.parent / ".test_media"
+        self.media_root = base_media_root / uuid.uuid4().hex
+        self.media_root.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(shutil.rmtree, self.media_root, ignore_errors=True)
+        self._media_settings = self.settings(MEDIA_ROOT=self.media_root)
+        self._media_settings.enable()
+        self.addCleanup(self._media_settings.disable)
+
+        post_save.disconnect(generate_variants_for_photo, sender=Photo)
+        self.addCleanup(post_save.connect, generate_variants_for_photo, sender=Photo)
+
         preview = SimpleUploadedFile("preview.jpg", b"preview", content_type="image/jpeg")
         high_res = SimpleUploadedFile("high_res.jpg", b"high_res", content_type="image/jpeg")
         self.photo = Photo.objects.create(
@@ -1846,6 +1857,16 @@ class ProdigiShipmentSyncCommandTests(TestCase):
         self.assertIn("Found 0 candidate Prodigi order(s)", stdout.getvalue())
 
     @patch("checkout.tracking.fetch_prodigi_order")
+    def test_command_ignores_orders_with_whitespace_only_prodigi_order_id(self, mock_fetch_prodigi_order):
+        self._create_physical_order(prodigi_order_id="   ")
+        stdout = StringIO()
+
+        call_command("sync_prodigi_shipments", stdout=stdout)
+
+        mock_fetch_prodigi_order.assert_not_called()
+        self.assertIn("Found 0 candidate Prodigi order(s)", stdout.getvalue())
+
+    @patch("checkout.tracking.fetch_prodigi_order")
     def test_command_limits_to_recent_candidate_orders(self, mock_fetch_prodigi_order):
         recent_order = self._create_physical_order(prodigi_order_id="ord_prodigi_recent")
         stale_order = self._create_physical_order(prodigi_order_id="ord_prodigi_stale")
@@ -1867,8 +1888,8 @@ class ProdigiShipmentSyncCommandTests(TestCase):
         self.assertEqual(stale_order.prodigi_status, "InProgress")
         self.assertIsNone(stale_order.prodigi_last_polled_at)
 
-    @patch("checkout.tracking.fetch_prodigi_order", side_effect=RuntimeError("debug lookup skipped"))
-    def test_debug_candidates_reports_real_physical_order_shape(self, _mock_fetch_prodigi_order):
+    @patch("checkout.tracking.fetch_prodigi_order")
+    def test_debug_candidates_reports_real_physical_order_shape(self, mock_fetch_prodigi_order):
         eligible_order = self._create_physical_order(
             prodigi_order_id="ord_prodigi_debug",
             prodigi_status="InProgress",
@@ -1884,6 +1905,7 @@ class ProdigiShipmentSyncCommandTests(TestCase):
 
         call_command("sync_prodigi_shipments", "--debug-candidates", stdout=stdout)
 
+        mock_fetch_prodigi_order.assert_not_called()
         output = stdout.getvalue()
         self.assertIn(eligible_order.order_number, output)
         self.assertIn("included=true", output)
@@ -1894,6 +1916,7 @@ class ProdigiShipmentSyncCommandTests(TestCase):
         self.assertIn("already_synced", output)
         self.assertIn(no_prodigi_order.order_number, output)
         self.assertIn("missing_prodigi_order_id", output)
+        self.assertIn("Debug mode only: no Prodigi sync was run.", output)
 
 
 @override_settings(

--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -1672,7 +1672,25 @@ class ProdigiTrackingCallbackTests(TestCase):
 )
 class ProdigiShipmentSyncCommandTests(TestCase):
     def setUp(self):
-        self.physical_content_type = ContentType.objects.get_for_model(PrintTemplate)
+        preview = SimpleUploadedFile("preview.jpg", b"preview", content_type="image/jpeg")
+        high_res = SimpleUploadedFile("high_res.jpg", b"high_res", content_type="image/jpeg")
+        self.photo = Photo.objects.create(
+            title="Prodigi Sync Photo",
+            description="Test description",
+            collection="Test Collection",
+            preview_image=preview,
+            high_res_file=high_res,
+            price=Decimal("25.00"),
+            is_active=True,
+            is_printable=True,
+        )
+        self.variant = ProductVariant.objects.create(
+            photo=self.photo,
+            material="eco_canvas",
+            size="12x18",
+            price=Decimal("99.00"),
+        )
+        self.physical_content_type = ContentType.objects.get_for_model(ProductVariant)
         self.template = PrintTemplate.objects.create(
             material="eco_canvas",
             size="12x18",
@@ -1696,7 +1714,7 @@ class ProdigiShipmentSyncCommandTests(TestCase):
             quantity=1,
             item_total=Decimal("99.00"),
             content_type=self.physical_content_type,
-            object_id=self.template.id,
+            object_id=self.variant.id,
             details={"product_type": "physical"},
         )
         return order
@@ -1848,6 +1866,34 @@ class ProdigiShipmentSyncCommandTests(TestCase):
         self.assertEqual(recent_order.prodigi_status, "Shipped")
         self.assertEqual(stale_order.prodigi_status, "InProgress")
         self.assertIsNone(stale_order.prodigi_last_polled_at)
+
+    @patch("checkout.tracking.fetch_prodigi_order", side_effect=RuntimeError("debug lookup skipped"))
+    def test_debug_candidates_reports_real_physical_order_shape(self, _mock_fetch_prodigi_order):
+        eligible_order = self._create_physical_order(
+            prodigi_order_id="ord_prodigi_debug",
+            prodigi_status="InProgress",
+        )
+        excluded_order = self._create_physical_order(
+            prodigi_order_id="ord_prodigi_done",
+            prodigi_status="Shipped",
+            tracking_email_sent_at=timezone.now(),
+            prodigi_last_polled_at=timezone.now(),
+        )
+        no_prodigi_order = self._create_physical_order(prodigi_order_id=None)
+        stdout = StringIO()
+
+        call_command("sync_prodigi_shipments", "--debug-candidates", stdout=stdout)
+
+        output = stdout.getvalue()
+        self.assertIn(eligible_order.order_number, output)
+        self.assertIn("included=true", output)
+        self.assertIn("status_not_final", output)
+        self.assertIn("tracking_email_not_sent", output)
+        self.assertIn("never_polled", output)
+        self.assertIn(excluded_order.order_number, output)
+        self.assertIn("already_synced", output)
+        self.assertIn(no_prodigi_order.order_number, output)
+        self.assertIn("missing_prodigi_order_id", output)
 
 
 @override_settings(

--- a/checkout/tracking.py
+++ b/checkout/tracking.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.core.mail import EmailMessage
 from django.db import transaction
 from django.db.models import Q
+from django.db.models.functions import Trim
 from django.template.loader import render_to_string
 from django.utils import timezone
 
@@ -291,7 +292,8 @@ def get_prodigi_sync_candidates(*, lookback_days: int = 90):
             date__gte=cutoff,
             prodigi_order_id__isnull=False,
         )
-        .exclude(prodigi_order_id="")
+        .annotate(prodigi_order_id_trimmed=Trim("prodigi_order_id"))
+        .exclude(prodigi_order_id_trimmed="")
         .filter(
             Q(prodigi_status__isnull=True)
             | Q(prodigi_status="")

--- a/checkout/tracking.py
+++ b/checkout/tracking.py
@@ -2,17 +2,15 @@ import hashlib
 import json
 import logging
 from datetime import timedelta
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Tuple
 
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
 from django.core.mail import EmailMessage
 from django.db import transaction
 from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils import timezone
 
-from products.models import PrintTemplate
 from openeire_api.mail_utils import get_contact_email_address, get_default_from_email
 
 from .models import Order
@@ -262,8 +260,29 @@ def refresh_order_from_prodigi(order, *, mark_polled: bool = False):
     return sync_result
 
 
+def _has_prodigi_order_id(order) -> bool:
+    return bool(str(order.prodigi_order_id or "").strip())
+
+
+def get_prodigi_sync_candidate_status(order) -> Tuple[bool, List[str]]:
+    reasons: List[str] = []
+
+    if not _has_prodigi_order_id(order):
+        return False, ["missing_prodigi_order_id"]
+
+    if order.prodigi_status not in FINAL_PRODIGI_SYNC_STATES:
+        reasons.append("status_not_final")
+    if order.tracking_email_sent_at is None:
+        reasons.append("tracking_email_not_sent")
+    if order.prodigi_last_polled_at is None:
+        reasons.append("never_polled")
+
+    if reasons:
+        return True, reasons
+    return False, ["already_synced"]
+
+
 def get_prodigi_sync_candidates(*, lookback_days: int = 90):
-    physical_content_type = ContentType.objects.get_for_model(PrintTemplate)
     lookback_days = max(int(lookback_days or 0), 1)
     cutoff = timezone.now() - timedelta(days=lookback_days)
 
@@ -271,7 +290,6 @@ def get_prodigi_sync_candidates(*, lookback_days: int = 90):
         Order.objects.filter(
             date__gte=cutoff,
             prodigi_order_id__isnull=False,
-            items__content_type=physical_content_type,
         )
         .exclude(prodigi_order_id="")
         .filter(
@@ -281,8 +299,30 @@ def get_prodigi_sync_candidates(*, lookback_days: int = 90):
             | Q(tracking_email_sent_at__isnull=True)
             | Q(prodigi_last_polled_at__isnull=True)
         )
-        .distinct()
+        .order_by("-date")
     )
+
+
+def get_prodigi_sync_debug_rows(*, lookback_days: int = 90):
+    lookback_days = max(int(lookback_days or 0), 1)
+    cutoff = timezone.now() - timedelta(days=lookback_days)
+    rows = []
+
+    for order in Order.objects.filter(date__gte=cutoff).order_by("-date"):
+        included, reasons = get_prodigi_sync_candidate_status(order)
+        rows.append(
+            {
+                "order_number": order.order_number,
+                "prodigi_order_id": str(order.prodigi_order_id or "").strip() or "n/a",
+                "prodigi_status": str(order.prodigi_status or "").strip() or "n/a",
+                "tracking_email_sent_at": order.tracking_email_sent_at,
+                "prodigi_last_polled_at": order.prodigi_last_polled_at,
+                "included": included,
+                "reasons": reasons,
+            }
+        )
+
+    return rows
 
 
 def send_tracking_email(order, shipments: Iterable[dict], *, order_stage: object = ""):


### PR DESCRIPTION
## Summary

This PR fixes the scheduled Prodigi shipment sync candidate selection so real recent Prodigi-backed orders are no longer excluded incorrectly. It also adds a debug mode to explain why orders are included or skipped.

## Why

The command was finding 0 candidates even when Django admin showed a recent order with a `prodigi_order_id`, `InProgress` status, no `prodigi_last_polled_at`, and no `tracking_email_sent_at`. The root cause was an overly strict physical-item filter that did not match the current checkout order item shape.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Relaxed scheduled Prodigi sync candidate filtering to rely on recent date + non-empty `prodigi_order_id` + unsynced state markers
  - Added `--debug-candidates` to `sync_prodigi_shipments`
  - Added candidate/exclusion reason reporting without secrets
  - Updated tests to reflect real `ProductVariant` physical order items
- Frontend:
  - None
- Infra/Config:
  - None

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally
- [ ] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described:

Hotfix path described:
- Revert this PR if candidate filtering becomes too broad
- Continue using the existing admin action `Refresh selected orders from Prodigi`

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [ ] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)