### PR TITLE
Fix password change endpoint 500

### DIFF
--- a/userprofiles/tests.py
+++ b/userprofiles/tests.py
@@ -150,6 +150,49 @@ class UserProfileCountrySerializationTests(TestCase):
         self.assertEqual(response.json()["country"], "US")
 
 
+class ChangePasswordTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username="changepassworduser",
+            email="changepassword@example.com",
+            password="StrongPass123!",
+            is_active=True,
+        )
+        self.url = reverse("auth_password_change")
+        self.client.force_authenticate(user=self.user)
+
+    def test_change_password_updates_authenticated_user_password(self):
+        response = self.client.put(
+            self.url,
+            data={
+                "old_password": "StrongPass123!",
+                "new_password": "NewStrongPass456!",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("message"), "Password updated successfully")
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("NewStrongPass456!"))
+
+    def test_change_password_rejects_wrong_current_password(self):
+        response = self.client.put(
+            self.url,
+            data={
+                "old_password": "WrongPass123!",
+                "new_password": "NewStrongPass456!",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("old_password", response.json())
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("StrongPass123!"))
+
+
 @override_settings(
     EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
     DEFAULT_FROM_EMAIL="noreply@example.com",

--- a/userprofiles/views.py
+++ b/userprofiles/views.py
@@ -448,7 +448,7 @@ class ChangePasswordView(generics.UpdateAPIView):
 
     def update(self, request, *args, **kwargs):
         self.object = self.get_object()
-        serializer = self.get_serializer(data=request.data)
+        serializer = self.get_serializer(instance=self.object, data=request.data)
 
         if serializer.is_valid(raise_exception=True):
             # The serializer's .update() method handles password hashing and saving


### PR DESCRIPTION
## Summary

Fixes the authenticated password change endpoint so it updates the current user instead of hitting the serializer `create()` path and returning a 500.

## Why

Changing password from the new Next `/profile` security form triggered a backend 500 because `ChangePasswordSerializer` was instantiated without the authenticated user instance. DRF called `create()`, which intentionally raises `NotImplementedError`.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Passed the authenticated user instance into `ChangePasswordSerializer` in `ChangePasswordView.update()`
  - Added regression tests for successful password changes
  - Added regression tests for wrong-current-password validation
- Frontend:
  - None
- Infra/Config:
  - None

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally
- [ ] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

Test run:

```
.\.venv\Scripts\python.exe manage.py test userprofiles.tests.ChangePasswordTests
```

Result: 2 tests passed.

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)