### PR TITLE
Alert operations when paid orders fail Prodigi fulfilment

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ Email:
 - `LICENSING_FROM_EMAIL`
 - `LICENSOR_CONTACT_EMAIL`
 - `LICENCE_ADMIN_NOTIFICATION_RECIPIENTS`
+- `FULFILMENT_ALERT_RECIPIENTS` (comma-separated operations addresses; falls back to licence admin recipients or Django `ADMINS`)
+- `FULFILMENT_ALERT_COOLDOWN_SECONDS` (defaults to 24 hours per failed order)
+- `FULFILMENT_ADMIN_BASE_URL` (public API origin used to build the internal order-review link)
 
 Stripe:
 - `STRIPE_PUBLIC_KEY`

--- a/checkout/alerts.py
+++ b/checkout/alerts.py
@@ -1,0 +1,160 @@
+import logging
+from typing import Any
+
+from django.conf import settings
+from django.core.cache import cache
+from django.core.mail import EmailMessage
+from django.urls import reverse
+from django.utils import timezone
+
+from openeire_api.mail_utils import get_default_from_email
+
+
+logger = logging.getLogger(__name__)
+
+ALERT_SEND_LOCK_SECONDS = 300
+
+
+def _safe_alert_value(value: Any, *, fallback: str, max_length: int = 200) -> str:
+    """Keep provider-supplied diagnostics compact and single-line in alerts."""
+    text = " ".join(str(value or "").split())
+    return (text or fallback)[:max_length]
+
+
+def get_fulfilment_alert_recipients() -> list[str]:
+    configured = list(
+        getattr(settings, "FULFILMENT_ALERT_RECIPIENTS", []) or []
+    )
+    if configured:
+        return configured
+
+    licence_recipients = list(
+        getattr(settings, "LICENCE_ADMIN_NOTIFICATION_RECIPIENTS", []) or []
+    )
+    if licence_recipients:
+        return licence_recipients
+
+    admins = getattr(settings, "ADMINS", ()) or ()
+    return [email for _, email in admins if email]
+
+
+def send_fulfilment_failure_alert(order, error):
+    """Send one actionable alert per failed order within the cooldown window."""
+    recipients = get_fulfilment_alert_recipients()
+    if not recipients:
+        logger.error(
+            "Paid order fulfilment failed but no alert recipients are configured. order=%s",
+            order.order_number,
+        )
+        return False
+
+    sent_cache_key = f"fulfilment-failure-alert-sent:{order.pk}"
+    lock_cache_key = f"fulfilment-failure-alert-lock:{order.pk}"
+    cooldown = max(
+        int(getattr(settings, "FULFILMENT_ALERT_COOLDOWN_SECONDS", 86400)),
+        60,
+    )
+    cache_available = True
+    try:
+        if cache.get(sent_cache_key):
+            return False
+        should_send = cache.add(
+            lock_cache_key,
+            "1",
+            timeout=ALERT_SEND_LOCK_SECONDS,
+        )
+    except Exception:
+        logger.exception(
+            "Fulfilment alert cache unavailable; sending without deduplication. order=%s",
+            order.order_number,
+        )
+        cache_available = False
+        should_send = True
+
+    if not should_send:
+        return False
+
+    trace_parent = _safe_alert_value(
+        getattr(error, "trace_parent", None),
+        fallback="Not provided",
+    )
+    outcome = _safe_alert_value(
+        getattr(error, "outcome", None),
+        fallback=error.__class__.__name__,
+    )
+    status_code = getattr(error, "status_code", None)
+    prodigi_order_id = _safe_alert_value(
+        getattr(order, "prodigi_order_id", None),
+        fallback="Not recorded",
+    )
+    admin_path = reverse(
+        "customadmin:checkout_order_change",
+        args=[order.pk],
+    )
+    admin_base_url = (
+        getattr(settings, "FULFILMENT_ADMIN_BASE_URL", None)
+        or getattr(settings, "PRODIGI_CALLBACK_BASE_URL", None)
+        or getattr(settings, "SITE_URL", None)
+    )
+    admin_url = (
+        f"{str(admin_base_url).rstrip('/')}{admin_path}"
+        if admin_base_url
+        else admin_path
+    )
+
+    prodigi_acceptance_recorded = prodigi_order_id != "Not recorded"
+    incident_summary = (
+        "Prodigi returned an order ID, but local post-submission processing failed."
+        if prodigi_acceptance_recorded
+        else "The application could not confirm that Prodigi accepted the physical order."
+    )
+    required_action = (
+        "Do not submit a duplicate order. Open the existing Prodigi order and review its status."
+        if prodigi_acceptance_recorded
+        else "Search Prodigi using the OpenEire order number before manually submitting anything. "
+        "If no order exists, manually fulfil or refund the paid order as appropriate."
+    )
+
+    subject = f"URGENT: paid order needs fulfilment review - {order.order_number}"
+    body = (
+        f"A customer payment succeeded. {incident_summary}\n\n"
+        f"Order: {order.order_number}\n"
+        f"Detected: {timezone.localtime().strftime('%Y-%m-%d %H:%M %Z')}\n"
+        f"Order total: EUR {order.total_price}\n"
+        f"Prodigi status: {order.prodigi_status or 'FULFILMENT_FAILED'}\n"
+        f"Prodigi order ID: {prodigi_order_id}\n"
+        f"Prodigi HTTP status: {status_code or 'Not provided'}\n"
+        f"Prodigi outcome: {outcome}\n"
+        f"Prodigi trace: {trace_parent}\n\n"
+        f"ACTION REQUIRED: {required_action}\n\n"
+        f"Review the order in admin: {admin_url}\n"
+    )
+
+    email = EmailMessage(
+        subject=subject,
+        body=body,
+        from_email=get_default_from_email(),
+        to=recipients,
+    )
+    try:
+        email.send(fail_silently=False)
+    except Exception:
+        if cache_available:
+            try:
+                cache.delete(lock_cache_key)
+            except Exception:
+                pass
+        raise
+
+    if cache_available:
+        try:
+            # Record successful delivery after sending. A cache failure may cause a
+            # duplicate alert on retry, but it cannot hide an unsent alert.
+            cache.set(sent_cache_key, "1", timeout=cooldown)
+            cache.delete(lock_cache_key)
+        except Exception:
+            logger.exception(
+                "Could not persist fulfilment alert deduplication state. order=%s",
+                order.order_number,
+            )
+    return True

--- a/checkout/apps.py
+++ b/checkout/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class CheckoutConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'checkout'
+
+    def ready(self):
+        from . import checks  # noqa: F401

--- a/checkout/checks.py
+++ b/checkout/checks.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.core import checks
+
+from checkout.alerts import get_fulfilment_alert_recipients
+
+
+@checks.register(checks.Tags.security)
+def check_fulfilment_alert_recipients(app_configs, **kwargs):
+    if (
+        getattr(settings, "DEBUG", False)
+        or getattr(settings, "IS_TEST_ENV", False)
+        or get_fulfilment_alert_recipients()
+    ):
+        return []
+
+    return [
+        checks.Error(
+            "Paid-order fulfilment alerts have no configured recipients.",
+            hint=(
+                "Set FULFILMENT_ALERT_RECIPIENTS to one or more monitored "
+                "operations email addresses."
+            ),
+            id="checkout.E001",
+        )
+    ]

--- a/checkout/prodigi.py
+++ b/checkout/prodigi.py
@@ -12,6 +12,16 @@ from django.urls import reverse
 logger = logging.getLogger(__name__)
 
 
+class ProdigiFulfillmentError(RuntimeError):
+    def __init__(self, *, status_code, outcome=None, trace_parent=None):
+        self.status_code = status_code
+        self.outcome = outcome or "unknown"
+        self.trace_parent = trace_parent
+        super().__init__(
+            f"Prodigi fulfillment failed (status={status_code}, outcome={self.outcome})."
+        )
+
+
 def _is_non_public_prodigi_asset_url(url: str) -> bool:
     raw_url = str(url or "").strip()
     if not raw_url:
@@ -448,6 +458,8 @@ def create_prodigi_order(order):
         trace_parent or "n/a",
         ",".join(failure_codes) if failure_codes else "none",
     )
-    raise RuntimeError(
-        f"Prodigi fulfillment failed (status={response.status_code}, outcome={outcome or 'unknown'})."
+    raise ProdigiFulfillmentError(
+        status_code=response.status_code,
+        outcome=outcome,
+        trace_parent=trace_parent,
     )

--- a/checkout/test_alerts.py
+++ b/checkout/test_alerts.py
@@ -1,0 +1,137 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.core import mail
+from django.test import SimpleTestCase, override_settings
+from django.urls import reverse
+
+from checkout.alerts import send_fulfilment_failure_alert
+from checkout.checks import check_fulfilment_alert_recipients
+
+
+@override_settings(
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    DEFAULT_FROM_EMAIL="OpenEire Studios <studio@example.com>",
+    FULFILMENT_ALERT_RECIPIENTS=["operations@example.com"],
+    FULFILMENT_ADMIN_BASE_URL="https://api.example.com",
+)
+class FulfilmentFailureAlertTests(SimpleTestCase):
+    def setUp(self):
+        self.order = SimpleNamespace(
+            pk=42,
+            order_number="ORDER123",
+            total_price="120.00",
+            prodigi_status="FULFILMENT_FAILED",
+            prodigi_order_id=None,
+        )
+        self.error = SimpleNamespace(
+            status_code=500,
+            outcome="InternalServerError",
+            trace_parent="00-safe-trace",
+        )
+
+    @patch("checkout.alerts.cache.delete")
+    @patch("checkout.alerts.cache.set")
+    @patch("checkout.alerts.cache.add", return_value=True)
+    @patch("checkout.alerts.cache.get", return_value=None)
+    def test_alert_contains_actionable_safe_details(
+        self,
+        _mock_cache_get,
+        _mock_cache_add,
+        mock_cache_set,
+        _mock_cache_delete,
+    ):
+        sent = send_fulfilment_failure_alert(self.order, self.error)
+
+        self.assertTrue(sent)
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(email.to, ["operations@example.com"])
+        self.assertIn("ORDER123", email.subject)
+        self.assertIn("payment succeeded", email.body)
+        self.assertIn("00-safe-trace", email.body)
+        self.assertIn("Search Prodigi", email.body)
+        self.assertIn(
+            f"https://api.example.com{reverse('customadmin:checkout_order_change', args=[42])}",
+            email.body,
+        )
+        mock_cache_set.assert_called_once()
+
+    @patch("checkout.alerts.cache.get", return_value="1")
+    def test_duplicate_alert_is_suppressed(self, _mock_cache_get):
+        sent = send_fulfilment_failure_alert(self.order, self.error)
+
+        self.assertFalse(sent)
+        self.assertEqual(mail.outbox, [])
+
+    @patch("checkout.alerts.EmailMessage.send", side_effect=RuntimeError("smtp offline"))
+    @patch("checkout.alerts.cache.delete")
+    @patch("checkout.alerts.cache.set")
+    @patch("checkout.alerts.cache.add", return_value=True)
+    @patch("checkout.alerts.cache.get", return_value=None)
+    def test_failed_email_releases_lock_without_marking_alert_sent(
+        self,
+        _mock_cache_get,
+        _mock_cache_add,
+        mock_cache_set,
+        mock_cache_delete,
+        _mock_email_send,
+    ):
+        with self.assertRaisesRegex(RuntimeError, "smtp offline"):
+            send_fulfilment_failure_alert(self.order, self.error)
+
+        mock_cache_set.assert_not_called()
+        mock_cache_delete.assert_called_once_with(
+            "fulfilment-failure-alert-lock:42"
+        )
+
+    @override_settings(
+        FULFILMENT_ALERT_RECIPIENTS=[],
+        LICENCE_ADMIN_NOTIFICATION_RECIPIENTS=["licensing-ops@example.com"],
+    )
+    @patch("checkout.alerts.cache.delete")
+    @patch("checkout.alerts.cache.set")
+    @patch("checkout.alerts.cache.add", return_value=True)
+    @patch("checkout.alerts.cache.get", return_value=None)
+    def test_existing_admin_recipient_is_used_as_safe_fallback(
+        self,
+        _mock_cache_get,
+        _mock_cache_add,
+        _mock_cache_set,
+        _mock_cache_delete,
+    ):
+        sent = send_fulfilment_failure_alert(self.order, self.error)
+
+        self.assertTrue(sent)
+        self.assertEqual(mail.outbox[0].to, ["licensing-ops@example.com"])
+
+    @patch("checkout.alerts.cache.delete")
+    @patch("checkout.alerts.cache.set")
+    @patch("checkout.alerts.cache.add", return_value=True)
+    @patch("checkout.alerts.cache.get", return_value=None)
+    def test_alert_warns_against_duplicate_when_prodigi_id_exists(
+        self,
+        _mock_cache_get,
+        _mock_cache_add,
+        _mock_cache_set,
+        _mock_cache_delete,
+    ):
+        self.order.prodigi_order_id = "ord_prodigi_123"
+
+        sent = send_fulfilment_failure_alert(self.order, self.error)
+
+        self.assertTrue(sent)
+        self.assertIn("ord_prodigi_123", mail.outbox[0].body)
+        self.assertIn("Do not submit a duplicate order", mail.outbox[0].body)
+
+    @override_settings(
+        DEBUG=False,
+        IS_TEST_ENV=False,
+        FULFILMENT_ALERT_RECIPIENTS=[],
+        LICENCE_ADMIN_NOTIFICATION_RECIPIENTS=[],
+        ADMINS=[],
+    )
+    def test_production_check_requires_an_alert_recipient(self):
+        errors = check_fulfilment_alert_recipients(None)
+
+        self.assertEqual([error.id for error in errors], ["checkout.E001"])

--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -1828,12 +1828,14 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
         order = Order.objects.get()
         self.assertEqual(DiscountRedemption.objects.filter(order=order).count(), 1)
 
+    @patch("checkout.views.send_fulfilment_failure_alert")
     @patch("checkout.views.create_prodigi_order", side_effect=RuntimeError("prodigi offline"))
     @patch("checkout.views.stripe.Webhook.construct_event")
     def test_webhook_marks_physical_fulfilment_failure_visible_and_retryable(
         self,
         mock_construct,
         _mock_create_prodigi_order,
+        mock_send_fulfilment_failure_alert,
     ):
         mock_construct.return_value = self._physical_payment_intent_event()
 
@@ -1852,6 +1854,10 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
         self.assertEqual(event.status, "FAILED")
         self.assertIn(order.order_number, event.error_message)
         self.assertIn("prodigi offline", event.error_message)
+        mock_send_fulfilment_failure_alert.assert_called_once()
+        alerted_order, alerted_error = mock_send_fulfilment_failure_alert.call_args.args
+        self.assertEqual(alerted_order.pk, order.pk)
+        self.assertEqual(str(alerted_error), "prodigi offline")
 
     @patch("checkout.views.create_prodigi_order")
     @patch("checkout.views.stripe.Webhook.construct_event")
@@ -1895,6 +1901,45 @@ class ConsumerDigitalOrderLicenceTests(TestCase):
         event = StripeWebhookEvent.objects.get(stripe_event_id="evt_physical_retry")
         self.assertEqual(event.status, "SUCCESS")
         self.assertEqual(mock_create_prodigi_order.call_count, 2)
+
+    @patch("checkout.views.send_fulfilment_failure_alert")
+    @patch(
+        "checkout.views.sync_order_shipping_from_prodigi",
+        side_effect=RuntimeError("local sync failed"),
+    )
+    @patch("checkout.views.create_prodigi_order")
+    @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_post_submission_failure_preserves_prodigi_order_id(
+        self,
+        mock_construct,
+        mock_create_prodigi_order,
+        _mock_sync_order_shipping,
+        mock_send_fulfilment_failure_alert,
+    ):
+        mock_construct.return_value = self._physical_payment_intent_event()
+        mock_create_prodigi_order.return_value = {
+            "order": {
+                "id": "ord_prodigi_already_created",
+                "status": {"stage": "InProduction"},
+                "merchantReference": "",
+                "shipments": [],
+            }
+        }
+
+        response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 500)
+        order = Order.objects.get()
+        self.assertEqual(order.prodigi_order_id, "ord_prodigi_already_created")
+        self.assertEqual(order.prodigi_status, "SUBMITTED")
+        mock_send_fulfilment_failure_alert.assert_called_once()
+        alerted_order = mock_send_fulfilment_failure_alert.call_args.args[0]
+        self.assertEqual(alerted_order.prodigi_order_id, "ord_prodigi_already_created")
 
     @patch("checkout.views.create_prodigi_order")
     @patch("checkout.views.stripe.Webhook.construct_event")

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -52,6 +52,7 @@ from .discounts import (
 )
 from .address_validation import validate_physical_shipping_address
 from .prodigi import create_prodigi_order, fetch_prodigi_order
+from .alerts import send_fulfilment_failure_alert
 from .order_claiming import claim_guest_orders_for_user
 from .emails import send_order_confirmation_email
 from .shipping import (
@@ -1278,6 +1279,14 @@ class StripeWebhookView(APIView):
                                     if isinstance(prodigi_response, dict):
                                         prodigi_order = prodigi_response.get("order")
                                         if isinstance(prodigi_order, dict):
+                                            accepted_order_id = str(
+                                                prodigi_order.get("id") or ""
+                                            ).strip()
+                                            if accepted_order_id:
+                                                order.prodigi_order_id = accepted_order_id
+                                                order.save(
+                                                    update_fields=["prodigi_order_id"]
+                                                )
                                             sync_order_shipping_from_prodigi(order, prodigi_order)
                                     order.refresh_from_db(
                                         fields=[
@@ -1302,18 +1311,43 @@ class StripeWebhookView(APIView):
                                 order.order_number,
                             )
                     except Exception as exc:
-                        if order.prodigi_status != "FULFILMENT_FAILED":
+                        prodigi_order_id = str(order.prodigi_order_id or "").strip()
+                        if prodigi_order_id:
+                            if order.prodigi_status in (None, "", "SUBMITTING", "FULFILMENT_FAILED"):
+                                order.prodigi_status = "SUBMITTED"
+                        elif order.prodigi_status != "FULFILMENT_FAILED":
                             order.prodigi_status = "FULFILMENT_FAILED"
                         order.prodigi_submission_started_at = None
-                        order.save(
-                            update_fields=[
-                                "prodigi_status",
-                                "prodigi_submission_started_at",
-                            ]
-                        )
-                        processing_error = (
-                            f"Physical fulfilment failed for order {order.order_number}: {exc}"
-                        )
+                        update_fields = [
+                            "prodigi_status",
+                            "prodigi_submission_started_at",
+                        ]
+                        if prodigi_order_id:
+                            update_fields.append("prodigi_order_id")
+                        try:
+                            order.save(update_fields=update_fields)
+                        except Exception:
+                            logger.exception(
+                                "Failed to persist paid-order fulfilment failure state. "
+                                "order_number=%s",
+                                order.order_number,
+                            )
+                        try:
+                            send_fulfilment_failure_alert(order, exc)
+                        except Exception:
+                            logger.exception(
+                                "Failed to send paid-order fulfilment alert. order_number=%s",
+                                order.order_number,
+                            )
+                        if prodigi_order_id:
+                            processing_error = (
+                                "Prodigi accepted physical order "
+                                f"{order.order_number}, but local post-submission processing failed: {exc}"
+                            )
+                        else:
+                            processing_error = (
+                                f"Physical fulfilment failed for order {order.order_number}: {exc}"
+                            )
                         retryable_processing_error = True
                         logger.exception(
                             "Failed to fulfill order after webhook processing. order_number=%s",

--- a/openeire_api/settings.py
+++ b/openeire_api/settings.py
@@ -528,6 +528,15 @@ LICENCE_ADMIN_NOTIFICATION_RECIPIENTS = [
     for email in os.getenv('LICENCE_ADMIN_NOTIFICATION_RECIPIENTS', '').split(',')
     if email.strip()
 ]
+FULFILMENT_ALERT_RECIPIENTS = [
+    email.strip()
+    for email in os.getenv('FULFILMENT_ALERT_RECIPIENTS', '').split(',')
+    if email.strip()
+]
+FULFILMENT_ALERT_COOLDOWN_SECONDS = int(
+    os.getenv('FULFILMENT_ALERT_COOLDOWN_SECONDS', '86400')
+)
+FULFILMENT_ADMIN_BASE_URL = os.getenv('FULFILMENT_ADMIN_BASE_URL')
 LICENCE_OFFER_EXPIRY_DAYS = int(os.getenv('LICENCE_OFFER_EXPIRY_DAYS', '7'))
 BREVO_ENABLED = env_bool(
     os.getenv("BREVO_ENABLED"),


### PR DESCRIPTION
## Summary

Adds urgent email alerts when a paid physical order cannot be confirmed as submitted to Prodigi. It preserves retry/idempotency behaviour and distinguishes genuine rejection from failures after Prodigi has already accepted the order.

## Why

A customer payment can succeed before Prodigi submission fails. Operations need immediate, actionable notification so the order can be checked, manually fulfilled, or refunded without risking duplicate fulfilment.

## Screenshots / Demo

- [x] Not needed
- [ ] Added

## Changes

- Backend: Send an urgent operational alert with the order reference, Prodigi trace, status, and admin link.
- Backend: Deduplicate alerts only after successful email delivery.
- Backend: Release the alert lock when SMTP delivery fails so a Stripe retry can alert again.
- Backend: Preserve accepted Prodigi order IDs during local post-submission failures.
- Backend: Warn operators not to manually duplicate orders already accepted by Prodigi.
- Backend: Keep true submission failures visible as `FULFILMENT_FAILED`.
- Backend: Add a production system check requiring a monitored alert recipient.
- Backend: Add regression tests covering retries, SMTP failure, deduplication, and post-submission errors.
- Frontend: No changes.
- Infra/Config: Add fulfilment alert recipient, cooldown, and admin-base settings.

## Testing

- [x] All 134 checkout tests pass locally
- [x] Django system check passes
- [x] Migration check passes with no changes
- [ ] React build passes locally
- [x] Manual Stripe and Prodigi smoke test done

### Manual smoke test checklist (quick)

- [x] Successful orders still reach Prodigi
- [x] Duplicate Stripe webhooks do not duplicate orders
- [x] Failed Prodigi submission remains retryable
- [x] Accepted Prodigi ID survives a local sync failure
- [x] SMTP failure does not falsely mark an alert as sent
- [ ] Send a production alert test after deployment
- [ ] Confirm the monitored mailbox receives the alert and admin link works

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Stripe webhook idempotency
- [x] Prodigi duplicate-order prevention
- [x] Alert delivery failure handling
- [x] Sensitive-data exposure
- [x] Maintainability

## Deployment Configuration

Set before deploying:

FULFILMENT_ALERT_RECIPIENTS=your-monitored-email@example.com
FULFILMENT_ADMIN_BASE_URL=https://api.openeire.ie
FULFILMENT_ALERT_COOLDOWN_SECONDS=86400

No database migration is required. Existing React API contracts remain unchanged.