### PR TITLE
Harden public throttles and download token locking

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404
 from .models import BlogPost, Comment
 from .serializers import BlogPostListSerializer, BlogPostDetailSerializer, CommentSerializer
 from products.views import CustomPagination
+from openeire_api.throttling import SharedScopedRateThrottle
 
 class BlogPostListView(generics.ListAPIView):
     """
@@ -60,6 +61,12 @@ class BlogPostLikeView(APIView):
 
 class CommentListCreateView(generics.ListCreateAPIView):
     serializer_class = CommentSerializer
+
+    def get_throttles(self):
+        if self.request.method == 'POST':
+            self.throttle_scope = 'blog_comment'
+            return [SharedScopedRateThrottle()]
+        return []
 
     def get_permissions(self):
         if self.request.method == 'POST':

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -596,6 +596,8 @@ class CreatePaymentIntentView(APIView):
 
 class DiscountValidationView(APIView):
     permission_classes = [AllowAny]
+    throttle_classes = [SharedScopedRateThrottle]
+    throttle_scope = "discount_validation"
 
     def post(self, request, *args, **kwargs):
         cart = request.data.get("cart")

--- a/openeire_api/settings.py
+++ b/openeire_api/settings.py
@@ -205,6 +205,8 @@ REST_FRAMEWORK = {
         'gallery_access_verify': '20/hour',
         'real_estate_enquiry': '5/hour',
         'checkout_payment_intent': '60/hour',
+        'discount_validation': '30/hour',
+        'blog_comment': '20/hour',
         'prodigi_callback': '30/minute',
     },
 }

--- a/products/views.py
+++ b/products/views.py
@@ -888,27 +888,35 @@ class PersonalAssetDownloadView(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request, token):
-        token_obj = PersonalDownloadToken.objects.select_related("order_item").filter(token=token).first()
-        if not token_obj or not token_obj.is_valid:
-            raise Http404("Download link has expired or was already used.")
+        with transaction.atomic():
+            token_obj = (
+                PersonalDownloadToken.objects
+                .select_for_update()
+                .filter(token=token)
+                .first()
+            )
+            if not token_obj or not token_obj.is_valid:
+                raise Http404("Download link has expired or was already used.")
 
-        order_item = token_obj.order_item
-        asset = order_item.product
-        asset_file_name = get_asset_file_name(asset)
-        redirect_response = _redirect_to_private_asset_if_supported(
-            asset,
-            asset_file_name,
-            (asset_file_name or "").rsplit("/", 1)[-1],
-        )
-        if redirect_response is not None:
-            PersonalDownloadToken.objects.filter(pk=token_obj.pk).update(used_at=timezone.now())
-            return redirect_response
+            order_item = token_obj.order_item
+            asset = order_item.product
+            asset_file_name = get_asset_file_name(asset)
+            redirect_response = _redirect_to_private_asset_if_supported(
+                asset,
+                asset_file_name,
+                (asset_file_name or "").rsplit("/", 1)[-1],
+            )
+            if redirect_response is not None:
+                token_obj.used_at = timezone.now()
+                token_obj.save(update_fields=["used_at"])
+                return redirect_response
 
-        file_field = open_asset_file(asset, "rb")
-        if not file_field:
-            raise Http404("File not attached to asset")
+            file_field = open_asset_file(asset, "rb")
+            if not file_field:
+                raise Http404("File not attached to asset")
 
-        PersonalDownloadToken.objects.filter(pk=token_obj.pk).update(used_at=timezone.now())
+            token_obj.used_at = timezone.now()
+            token_obj.save(update_fields=["used_at"])
 
         filename = (get_asset_file_name(asset) or "").rsplit("/", 1)[-1]
         if not filename:


### PR DESCRIPTION
## Summary

Adds throttling to discount validation and blog comment submission, and hardens personal asset download tokens with row-level locking. This closes final launch audit gaps around abuse resistance and one-time token race safety.

## Why

Discount validation and blog comments are public/abusable flows that should be rate-limited before launch. Personal download tokens are intended to be one-time, so concurrent requests should not be able to reuse the same token.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Added `discount_validation` and `blog_comment` throttle rates.
  - Applied scoped throttling to discount validation.
  - Applied scoped throttling to blog comment POSTs while keeping public GET reads unthrottled.
  - Wrapped personal asset download token validation/use in an atomic `select_for_update()` transaction.
- Frontend:
  - N/A
- Infra/Config:
  - No new required env vars.
  - Existing `FULFILMENT_ALERT_RECIPIENTS` remains required in production.

## Testing

- [ ] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)