### PR TITLE
Chore/email admin workflow

### DIFF
--- a/openeire_api/pdf_markdown.py
+++ b/openeire_api/pdf_markdown.py
@@ -1,0 +1,127 @@
+import re
+
+from reportlab.lib import colors
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.platypus import Paragraph, Spacer, Table, TableStyle
+
+
+BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+ITALIC_RE = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+NUMBERED_RE = re.compile(r"^\s*\d+\.\s+")
+
+
+def apply_basic_markdown(text):
+    text = BOLD_RE.sub(r"<b>\1</b>", str(text))
+    return ITALIC_RE.sub(r"<i>\1</i>", text)
+
+
+def render_markdown_to_flowables(markdown_text):
+    styles = getSampleStyleSheet()
+    title_style = styles["Title"]
+    h2 = styles["Heading2"]
+    h3 = styles["Heading3"]
+    normal = styles["BodyText"]
+    normal.leading = 14
+
+    elements = []
+    lines = str(markdown_text or "").splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i].rstrip("\r")
+        if not line.strip():
+            i += 1
+            continue
+
+        if line.startswith("#"):
+            level = len(line) - len(line.lstrip("#"))
+            content = apply_basic_markdown(line[level:].strip())
+            style = title_style if level == 1 else h2 if level == 2 else h3
+            elements.append(Paragraph(content, style))
+            elements.append(Spacer(1, 6))
+            i += 1
+            continue
+
+        if line.strip() == "---":
+            elements.append(Spacer(1, 12))
+            i += 1
+            continue
+
+        if line.lstrip().startswith("- "):
+            while i < len(lines) and lines[i].lstrip().startswith("- "):
+                bullet_text = apply_basic_markdown(lines[i].lstrip()[2:].strip())
+                elements.append(Paragraph(bullet_text, normal, bulletText="\u2022"))
+                i += 1
+            elements.append(Spacer(1, 6))
+            continue
+
+        if NUMBERED_RE.match(line):
+            while i < len(lines) and NUMBERED_RE.match(lines[i]):
+                item = lines[i].strip()
+                num, text = item.split(".", 1)
+                bullet_text = apply_basic_markdown(text.strip())
+                elements.append(Paragraph(bullet_text, normal, bulletText=f"{num}."))
+                i += 1
+            elements.append(Spacer(1, 6))
+            continue
+
+        if line.strip().startswith("|") and i + 1 < len(lines) and lines[i + 1].strip().startswith("|"):
+            header = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            i += 2
+            rows = []
+            while i < len(lines) and lines[i].strip().startswith("|"):
+                rows.append([cell.strip() for cell in lines[i].strip().strip("|").split("|")])
+                i += 1
+
+            table_data = [[Paragraph(apply_basic_markdown(cell), normal) for cell in header]]
+            table_data.extend(
+                [[Paragraph(apply_basic_markdown(cell), normal) for cell in row] for row in rows]
+            )
+            table = Table(table_data, hAlign="LEFT")
+            table.setStyle(TableStyle([
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("BACKGROUND", (0, 0), (-1, 0), colors.whitesmoke),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]))
+            elements.append(table)
+            elements.append(Spacer(1, 12))
+            continue
+
+        paragraph_lines = [line]
+        i += 1
+        while i < len(lines):
+            next_line = lines[i]
+            if (
+                not next_line.strip()
+                or next_line.strip() == "---"
+                or next_line.startswith("#")
+                or next_line.lstrip().startswith("- ")
+                or NUMBERED_RE.match(next_line)
+                or (
+                    next_line.strip().startswith("|")
+                    and i + 1 < len(lines)
+                    and lines[i + 1].strip().startswith("|")
+                )
+            ):
+                break
+            paragraph_lines.append(next_line.rstrip("\r"))
+            i += 1
+
+        paragraph_text = ""
+        for part in paragraph_lines:
+            stripped = part.strip()
+            if not paragraph_text:
+                paragraph_text = stripped
+            elif paragraph_text.endswith("<br/>"):
+                paragraph_text += stripped
+            else:
+                paragraph_text += f" {stripped}"
+            if part.endswith("  "):
+                paragraph_text += "<br/>"
+        elements.append(Paragraph(apply_basic_markdown(paragraph_text), normal))
+        elements.append(Spacer(1, 6))
+
+    return elements

--- a/products/pdf_generator.py
+++ b/products/pdf_generator.py
@@ -2,18 +2,18 @@ from io import BytesIO
 from decimal import Decimal
 from pathlib import Path
 import hashlib
-import re
 from difflib import SequenceMatcher
 from xml.sax.saxutils import escape as xml_escape
 
 from django.conf import settings
 from django.utils import timezone
+from openeire_api.pdf_markdown import render_markdown_to_flowables
 
 from .file_access import get_asset_file_name, open_asset_file
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.platypus import (
     SimpleDocTemplate,
     Paragraph,
@@ -70,9 +70,6 @@ def _resolve_template_path(filename):
 
 COMMERCIAL_TEMPLATE_PATH = _resolve_template_path("COMMERCIAL RIGHTS-MANAGED LICENCE CERTIFICATE.md")
 PERSONAL_TEMPLATE_PATH = _resolve_template_path("PERSONAL USE LICENSE CERTIFICATE.md")
-
-BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
-
 
 def _load_template(path):
     if not path.exists():
@@ -263,124 +260,11 @@ def _replace_table(markdown_text, new_table_markdown, table_index=0):
     return "\n".join(lines[:start] + [new_table_markdown] + lines[end:])
 
 
-def _apply_basic_markdown(text):
-    return BOLD_RE.sub(r"<b>\1</b>", text)
-
-
 def _markdown_table_from_rows(headers, rows):
     header_line = "| " + " | ".join(headers) + " |"
     separator = "| " + " | ".join(["---"] * len(headers)) + " |"
     body = ["| " + " | ".join(str(cell) for cell in row) + " |" for row in rows]
     return "\n".join([header_line, separator] + body)
-
-
-def _render_markdown_to_flowables(markdown_text):
-    styles = getSampleStyleSheet()
-    title_style = styles["Title"]
-    h1 = styles["Heading1"]
-    h2 = styles["Heading2"]
-    h3 = styles["Heading3"]
-    normal = styles["BodyText"]
-    normal.leading = 14
-
-    elements = []
-    lines = markdown_text.splitlines()
-    i = 0
-    while i < len(lines):
-        line = lines[i].rstrip()
-        if not line.strip():
-            i += 1
-            continue
-
-        if line.startswith("#"):
-            level = len(line) - len(line.lstrip("#"))
-            content = line[level:].strip()
-            content = _apply_basic_markdown(content)
-            if level == 1:
-                style = title_style
-            elif level == 2:
-                style = h2
-            else:
-                style = h3
-            elements.append(Paragraph(content, style))
-            elements.append(Spacer(1, 6))
-            i += 1
-            continue
-
-        if line.strip() == "---":
-            elements.append(Spacer(1, 12))
-            i += 1
-            continue
-
-        if line.lstrip().startswith("- "):
-            bullets = []
-            while i < len(lines) and lines[i].lstrip().startswith("- "):
-                bullets.append(lines[i].lstrip()[2:].strip())
-                i += 1
-            for bullet in bullets:
-                bullet_text = _apply_basic_markdown(bullet)
-                elements.append(Paragraph(bullet_text, normal, bulletText="•"))
-            elements.append(Spacer(1, 6))
-            continue
-
-        if re.match(r"^\s*\d+\.\s+", line):
-            numbered = []
-            while i < len(lines) and re.match(r"^\s*\d+\.\s+", lines[i]):
-                numbered.append(lines[i].strip())
-                i += 1
-            for item in numbered:
-                num, text = item.split(".", 1)
-                bullet_text = _apply_basic_markdown(text.strip())
-                elements.append(Paragraph(bullet_text, normal, bulletText=f"{num}."))
-            elements.append(Spacer(1, 6))
-            continue
-
-        if line.strip().startswith("|") and i + 1 < len(lines) and lines[i + 1].strip().startswith("|"):
-            header = [cell.strip() for cell in line.strip().strip("|").split("|")]
-            i += 2
-            rows = []
-            while i < len(lines) and lines[i].strip().startswith("|"):
-                row = [cell.strip() for cell in lines[i].strip().strip("|").split("|")]
-                rows.append(row)
-                i += 1
-            table_data = [[Paragraph(_apply_basic_markdown(cell), normal) for cell in header]]
-            table_data.extend(
-                [[Paragraph(_apply_basic_markdown(cell), normal) for cell in row] for row in rows]
-            )
-            table = Table(table_data, hAlign="LEFT")
-            table.setStyle(TableStyle([
-                ("VALIGN", (0, 0), (-1, -1), "TOP"),
-                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
-                ("BACKGROUND", (0, 0), (-1, 0), colors.whitesmoke),
-                ("LEFTPADDING", (0, 0), (-1, -1), 6),
-                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
-                ("TOPPADDING", (0, 0), (-1, -1), 4),
-                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
-            ]))
-            elements.append(table)
-            elements.append(Spacer(1, 12))
-            continue
-
-        paragraph_lines = [line]
-        i += 1
-        while i < len(lines):
-            next_line = lines[i]
-            if (
-                not next_line.strip()
-                or next_line.strip() == "---"
-                or next_line.startswith("#")
-                or next_line.lstrip().startswith("- ")
-                or (next_line.strip().startswith("|") and i + 1 < len(lines) and lines[i + 1].strip().startswith("|"))
-            ):
-                break
-            paragraph_lines.append(next_line.rstrip())
-            i += 1
-        paragraph_text = " ".join(part.strip() for part in paragraph_lines)
-        paragraph_text = _apply_basic_markdown(paragraph_text)
-        elements.append(Paragraph(paragraph_text, normal))
-        elements.append(Spacer(1, 6))
-
-    return elements
 
 
 def generate_licence_schedule_pdf(license_request, issued_at=None, terms_version=None):
@@ -568,7 +452,7 @@ def generate_licence_certificate_pdf(license_request, issued_at=None, terms_vers
     template_text = _replace_table(template_text, asset_table, table_index=0)
     template_text = _replace_table(template_text, scope_table, table_index=1)
 
-    elements = _render_markdown_to_flowables(template_text)
+    elements = render_markdown_to_flowables(template_text)
 
     doc = SimpleDocTemplate(
         buffer,

--- a/products/personal_licence.py
+++ b/products/personal_licence.py
@@ -9,6 +9,8 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
 
+from openeire_api.pdf_markdown import render_markdown_to_flowables
+
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer
@@ -169,13 +171,7 @@ def generate_personal_licence_pdf(order):
     )
 
     licence_text = get_personal_licence_text() or "The full personal licence text is currently unavailable."
-    for block in licence_text.split("\n\n"):
-        cleaned = block.strip()
-        if not cleaned:
-            continue
-        paragraph = xml_escape(cleaned).replace("\n", "<br/>")
-        elements.append(Paragraph(paragraph, body_style))
-        elements.append(Spacer(1, 8))
+    elements.extend(render_markdown_to_flowables(licence_text))
 
     elements.extend(
         [

--- a/products/tests.py
+++ b/products/tests.py
@@ -25,6 +25,7 @@ from django.contrib.contenttypes.models import ContentType
 from checkout.models import Order, OrderItem
 from openeire_api.throttling import SharedScopedRateThrottle
 from openeire_api.admin import custom_admin_site
+from openeire_api.pdf_markdown import render_markdown_to_flowables
 from openeire_api.test_utils import decode_sender_header
 from .admin import LicenseRequestAdmin, LicenseRequestAdminForm
 from .models import (
@@ -46,7 +47,7 @@ from .licensing import (
     send_licence_negotiation_email,
     send_licence_quote_email,
 )
-from .personal_licence import ensure_personal_licence_token
+from .personal_licence import ensure_personal_licence_token, generate_personal_licence_pdf
 from .personal_downloads import ensure_personal_download_token
 from .uploads import build_object_key, sanitize_upload_filename
 
@@ -1548,6 +1549,30 @@ class LicenseRequestTests(APITestCase):
         second_response = self.client.get(url)
 
         self.assertEqual(second_response.status_code, 404)
+
+    def test_personal_licence_pdf_uses_shared_markdown_renderer(self):
+        user = User.objects.create_user(
+            username="personallicencemarkdown",
+            email="personallicencemarkdown@example.com",
+            password="testpass123",
+        )
+        order = Order.objects.create(
+            user_profile=user.userprofile,
+            first_name="Aisling",
+            email=user.email,
+            stripe_pid="pi_personal_licence_markdown",
+            personal_terms_version="PERSONAL v1.1 - March 2026",
+        )
+
+        with patch(
+            "products.personal_licence.render_markdown_to_flowables",
+            wraps=render_markdown_to_flowables,
+        ) as mock_renderer:
+            pdf_bytes = generate_personal_licence_pdf(order)
+
+        mock_renderer.assert_called_once()
+        self.assertTrue(pdf_bytes.startswith(b"%PDF"))
+        self.assertGreater(len(pdf_bytes), 1000)
 
     def test_personal_licence_download_token_fails_when_expired(self):
         user = User.objects.create_user(

--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -21,6 +21,7 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
         "status",
         "quoted_price",
         "shoot_date",
+        "booking_agreement_received",
     )
     list_filter = (
         "status",
@@ -93,6 +94,19 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
                     "status",
                     "quoted_price",
                     "shoot_date",
+                )
+            },
+        ),
+        (
+            "Booking & Delivery Links",
+            {
+                "fields": (
+                    "proposed_shoot_date",
+                    "booking_agreement_link",
+                    "booking_agreement_received",
+                    "deposit_payment_link",
+                    "delivery_link",
+                    "review_link",
                 )
             },
         ),

--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -6,6 +6,8 @@ from openeire_api.admin import custom_admin_site
 from .emails import build_realestate_email_context
 from .emails import get_realestate_reply_to_email
 from .emails import send_templated_email
+from .documents import build_booking_agreement_filename
+from .documents import generate_booking_agreement_pdf
 from .models import RealEstateEnquiry
 
 
@@ -157,6 +159,7 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
         extra_context=None,
         warning_messages=None,
         required_context=None,
+        attachment_builder=None,
     ):
         sent_count = 0
         failed_count = 0
@@ -200,12 +203,16 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
                     warnings.append(f"{enquiry}: {message}")
 
             try:
+                attachments = []
+                if attachment_builder:
+                    attachments = attachment_builder(enquiry, context)
                 send_templated_email(
                     subject=subject,
                     to=[email],
                     template_base=template_base,
                     context=build_realestate_email_context(enquiry, **context),
                     reply_to=self._get_reply_to(),
+                    attachments=attachments,
                 )
                 sent_count += 1
             except Exception as exc:
@@ -256,8 +263,12 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
             subject="Booking Agreement for your property media booking - OpenEire Studios",
             template_base="booking_agreement",
             description="Booking agreement email",
-            required_context=lambda enquiry, context: [
-                ("booking agreement link", context.get("booking_agreement_link")),
+            attachment_builder=lambda enquiry, context: [
+                (
+                    build_booking_agreement_filename(enquiry),
+                    generate_booking_agreement_pdf(enquiry),
+                    "application/pdf",
+                )
             ],
         )
 

--- a/realestate/docs/booking_agreement.md
+++ b/realestate/docs/booking_agreement.md
@@ -1,0 +1,99 @@
+# OpenEire Studios Real Estate Booking Agreement
+
+Booking reference: **{{ booking_reference }}**  
+Issued on: **{{ issued_on }}**
+
+---
+
+## 1. Parties
+
+**Client:** {{ client_name }}  
+**Company / agency:** {{ company_name }}  
+**Email:** {{ email }}  
+**Phone:** {{ phone }}
+
+**Supplier:** OpenEire Studios
+
+---
+
+## 2. Booking Details
+
+| Item | Details |
+| --- | --- |
+| Property | {{ property_address }} |
+| Property type | {{ property_type }} |
+| Package | {{ package_name }} |
+| Add-ons | {{ add_ons_summary }} |
+| Proposed shoot date | {{ shoot_date }} |
+| Quote total excluding VAT | {{ quote_total }} |
+
+---
+
+## 3. Scope
+
+OpenEire Studios will provide property media services for the property listed above, based on the package and add-ons agreed with the client.
+
+The final deliverables, timing, and access requirements remain subject to weather, safe drone operation, property readiness, permissions, and any written changes agreed before the shoot.
+
+---
+
+## 4. Client Responsibilities
+
+The client agrees to:
+
+- Ensure the property is ready for photography, video, drone, or virtual tour work before the scheduled appointment.
+- Confirm that access is available at the agreed time.
+- Obtain any required owner, occupier, management company, or neighbour permissions.
+- Notify OpenEire Studios of access restrictions, hazards, alarms, pets, parking issues, or sensitive areas before the shoot.
+- Ensure any people, vehicles, confidential documents, or personal items that should not appear in media are removed or identified before capture begins.
+
+---
+
+## 5. Booking Status and Deposit
+
+The booking remains provisional until:
+
+1. This Booking Agreement has been signed and returned.
+2. The required booking deposit has been received in cleared funds.
+
+The Deposit Request email will be issued separately after the signed Booking Agreement has been received.
+
+---
+
+## 6. Weather, Drone, and Rescheduling
+
+Drone and exterior media are subject to weather, daylight, airspace, safety, and legal operating conditions.
+
+If weather or site conditions prevent safe or suitable capture, OpenEire Studios may reschedule the affected part of the shoot or agree an alternative delivery approach with the client.
+
+---
+
+## 7. Delivery and Usage
+
+Delivered media may be used by the client for marketing the property identified in this agreement, including property portals, agency websites, printed brochures, and social media connected with that listing.
+
+Media must not be resold, relicensed, transferred to unrelated third parties, or used for unrelated properties, campaigns, or stock/media libraries without written permission from OpenEire Studios.
+
+---
+
+## 8. Cancellation and Changes
+
+Please provide as much notice as possible if the shoot needs to be changed or cancelled.
+
+OpenEire Studios may charge reasonable costs for late cancellations, failed access, or material scope changes where time or travel has already been committed.
+
+---
+
+## 9. Acceptance
+
+By signing and returning this agreement, the client confirms that the booking details are accurate and that they accept the booking terms above.
+
+Client signature: ______________________________
+
+Name: {{ client_name }}
+
+Date: ______________________________
+
+OpenEire Studios signature: ______________________________
+
+Date: ______________________________

--- a/realestate/documents.py
+++ b/realestate/documents.py
@@ -1,0 +1,113 @@
+from io import BytesIO
+from pathlib import Path
+from xml.sax.saxutils import escape as xml_escape
+
+from django.conf import settings
+from django.template import Context, Template
+from django.utils import timezone
+from django.utils.text import slugify
+
+from openeire_api.pdf_markdown import render_markdown_to_flowables
+
+from reportlab.lib.pagesizes import A4
+from reportlab.platypus import SimpleDocTemplate
+
+
+BOOKING_AGREEMENT_TEMPLATE_PATH = (
+    Path(__file__).resolve().parent / "docs" / "booking_agreement.md"
+)
+
+
+def _safe_value(value, default="Not specified"):
+    if value is None:
+        return default
+    text = str(value).strip()
+    if not text:
+        return default
+    return xml_escape(text)
+
+
+def _format_date(value, default="To be confirmed"):
+    if not value:
+        return default
+    if isinstance(value, str):
+        return _safe_value(value)
+    return value.strftime("%d %B %Y")
+
+
+def _format_money(value):
+    if value is None:
+        return "To be confirmed"
+    return f"EUR {value}"
+
+
+def _booking_reference(enquiry):
+    return f"RE-{enquiry.id}" if getattr(enquiry, "id", None) else "RE-DRAFT"
+
+
+def build_booking_agreement_filename(enquiry):
+    reference = _booking_reference(enquiry).lower()
+    name_part = slugify(getattr(enquiry, "name", "") or "client") or "client"
+    return f"openeire-booking-agreement-{reference}-{name_part}.pdf"
+
+
+def _load_booking_agreement_template():
+    path = Path(
+        getattr(settings, "REALESTATE_BOOKING_AGREEMENT_TEMPLATE", "")
+        or BOOKING_AGREEMENT_TEMPLATE_PATH
+    )
+    if not path.exists():
+        raise FileNotFoundError(f"Booking agreement template not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _build_booking_agreement_context(enquiry):
+    property_address = _safe_value(getattr(enquiry, "property_address", ""))
+    county = _safe_value(getattr(enquiry, "county", ""), default="")
+    if county:
+        property_address = f"{property_address}, {county}"
+
+    return {
+        "booking_reference": _booking_reference(enquiry),
+        "issued_on": timezone.localdate().strftime("%d %B %Y"),
+        "client_name": _safe_value(getattr(enquiry, "name", "")),
+        "company_name": _safe_value(getattr(enquiry, "company_name", ""), default="Not provided"),
+        "email": _safe_value(getattr(enquiry, "email", "")),
+        "phone": _safe_value(getattr(enquiry, "phone", "")),
+        "property_address": property_address,
+        "property_type": _safe_value(getattr(enquiry, "property_type", "")),
+        "package_name": _safe_value(
+            enquiry.get_preferred_package_summary()
+            if hasattr(enquiry, "get_preferred_package_summary")
+            else getattr(enquiry, "preferred_package", "")
+        ),
+        "add_ons_summary": _safe_value(
+            enquiry.get_add_ons_summary()
+            if hasattr(enquiry, "get_add_ons_summary")
+            else "",
+            default="None",
+        ),
+        "shoot_date": _format_date(
+            getattr(enquiry, "shoot_date", None)
+            or getattr(enquiry, "preferred_date", None)
+            or getattr(enquiry, "proposed_shoot_date", None)
+        ),
+        "quote_total": _format_money(getattr(enquiry, "quoted_price", None)),
+    }
+
+
+def generate_booking_agreement_pdf(enquiry):
+    template_text = _load_booking_agreement_template()
+    rendered_markdown = Template(template_text).render(
+        Context(_build_booking_agreement_context(enquiry), autoescape=False)
+    )
+
+    buffer = BytesIO()
+    document = SimpleDocTemplate(
+        buffer,
+        pagesize=A4,
+        title="OpenEire Studios Real Estate Booking Agreement",
+        author="OpenEire Studios",
+    )
+    document.build(render_markdown_to_flowables(rendered_markdown))
+    return buffer.getvalue()

--- a/realestate/tests.py
+++ b/realestate/tests.py
@@ -12,8 +12,11 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from openeire_api.admin import custom_admin_site
+from openeire_api.pdf_markdown import render_markdown_to_flowables
 
 from .admin import RealEstateEnquiryAdmin
+from .documents import build_booking_agreement_filename
+from .documents import generate_booking_agreement_pdf
 from .emails import build_realestate_email_context
 from .emails import format_money
 from .emails import send_templated_email
@@ -55,7 +58,8 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
     template_names = (
         "enquiry_reply",
         "quote",
-        "booking_agreement_deposit",
+        "booking_agreement",
+        "deposit_request",
         "confirmation",
         "delivery",
         "follow_up",
@@ -118,7 +122,11 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
             REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
         )
         booking_text = render_to_string(
-            "emails/real_estate/booking_agreement_deposit.txt",
+            "emails/real_estate/booking_agreement.txt",
+            REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
+        )
+        deposit_text = render_to_string(
+            "emails/real_estate/deposit_request.txt",
             REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
         )
         confirmation_text = render_to_string(
@@ -146,10 +154,10 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
             "This quote does not confirm a booking or reserve a shoot date.",
             quote_text,
         )
-        self.assertIn("Pay Secure Deposit:", booking_text)
         self.assertIn("Review Booking Agreement:", booking_text)
+        self.assertIn("Pay Secure Deposit:", deposit_text)
         self.assertIn(
-            "Your booking is not confirmed until both the signed agreement and deposit have been received in cleared funds.",
+            "Your booking remains provisional until the signed agreement has been received and the booking deposit has cleared.",
             booking_text,
         )
         self.assertIn(
@@ -269,7 +277,7 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
 
     def test_booking_deposit_cta_appears_with_deposit_link(self):
         html = render_to_string(
-            "emails/real_estate/booking_agreement_deposit.html",
+            "emails/real_estate/deposit_request.html",
             REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
         )
 
@@ -364,6 +372,56 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
             context["email_logo_url"].endswith(
                 "/static/emails/openeire-studios-logo.png"
             )
+        )
+
+
+class MarkdownPDFRendererTests(SimpleTestCase):
+    def test_renderer_supports_core_markdown_blocks(self):
+        flowables = render_markdown_to_flowables(
+            "# Title\n\n"
+            "## Section\n\n"
+            "Paragraph with **bold** and *italic* text.\n\n"
+            "- First bullet\n"
+            "- Second bullet\n\n"
+            "1. First item\n"
+            "2. Second item\n\n"
+            "| Field | Value |\n"
+            "| --- | --- |\n"
+            "| A | B |\n\n"
+            "---\n"
+        )
+
+        class_names = [flowable.__class__.__name__ for flowable in flowables]
+        self.assertIn("Paragraph", class_names)
+        self.assertIn("Table", class_names)
+        self.assertGreaterEqual(class_names.count("Paragraph"), 7)
+
+
+class BookingAgreementDocumentTests(TestCase):
+    def test_booking_agreement_pdf_generation_returns_pdf(self):
+        enquiry = RealEstateEnquiry.objects.create(
+            name="Jane Agent",
+            email="jane@example.com",
+            phone="+353 87 123 4567",
+            company_name="Example Estate Agents",
+            client_type=RealEstateEnquiry.ClientType.ESTATE_AGENT,
+            property_address="Example House, Salthill",
+            county="Galway",
+            eircode="H91 XXXX",
+            property_type="Detached house",
+            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            preferred_date="2026-06-20",
+            quoted_price="399.00",
+            consent_to_contact=True,
+        )
+
+        pdf_bytes = generate_booking_agreement_pdf(enquiry)
+
+        self.assertTrue(pdf_bytes.startswith(b"%PDF"))
+        self.assertGreater(len(pdf_bytes), 1000)
+        self.assertEqual(
+            build_booking_agreement_filename(enquiry),
+            f"openeire-booking-agreement-re-{enquiry.id}-jane-agent.pdf",
         )
 
 
@@ -596,7 +654,7 @@ class RealEstateEnquiryAdminActionTests(TestCase):
         )
 
     @patch("realestate.admin.send_templated_email")
-    def test_send_booking_agreement_email_skips_when_agreement_link_missing(self, mock_send_templated_email):
+    def test_send_booking_agreement_email_attaches_pdf_without_agreement_link(self, mock_send_templated_email):
         request = self._request()
 
         self.model_admin.send_booking_agreement_email(
@@ -604,14 +662,23 @@ class RealEstateEnquiryAdminActionTests(TestCase):
             RealEstateEnquiry.objects.filter(pk=self.enquiry.pk),
         )
 
-        mock_send_templated_email.assert_not_called()
-        warning_calls = [
-            call
-            for call in self.model_admin.message_user.call_args_list
-            if call.kwargs.get("level") == messages.WARNING
-        ]
-        self.assertTrue(
-            any("booking agreement link is missing" in call.args[1] for call in warning_calls)
+        mock_send_templated_email.assert_called_once()
+        kwargs = mock_send_templated_email.call_args.kwargs
+        self.assertEqual(kwargs["template_base"], "booking_agreement")
+        self.assertEqual(kwargs["to"], ["jane@example.com"])
+        self.assertEqual(kwargs["context"]["booking_agreement_link"], "")
+        self.assertEqual(len(kwargs["attachments"]), 1)
+        filename, content, mimetype = kwargs["attachments"][0]
+        self.assertEqual(
+            filename,
+            f"openeire-booking-agreement-re-{self.enquiry.id}-jane-agent.pdf",
+        )
+        self.assertTrue(content.startswith(b"%PDF"))
+        self.assertEqual(mimetype, "application/pdf")
+        self.model_admin.message_user.assert_any_call(
+            request,
+            "Booking agreement email sent for 1 enquiry(s).",
+            level=messages.SUCCESS,
         )
 
     @patch("realestate.admin.send_templated_email")


### PR DESCRIPTION
## Summary

This PR improves the real estate admin email workflow and PDF document generation.

It includes the previous admin update commit plus the new Markdown/PDF workflow work:

- adds missing real estate booking/delivery fields into Django admin
- extracts reusable Markdown-to-ReportLab PDF rendering
- refactors commercial licence PDFs to use the shared renderer without changing wording/placeholders/metadata/filenames
- refactors personal licence PDFs so Markdown renders properly instead of appearing as escaped plain text
- adds an editable Markdown source for the real estate booking agreement
- adds booking agreement PDF generation for real estate enquiries
- updates the “Send Booking Agreement Email” admin action to generate and attach the PDF automatically
- removes the requirement for `booking_agreement_link` when sending booking agreement emails
- keeps Deposit Request separate and still dependent on the deposit payment link / signed agreement state

## Architecture

A shared renderer now lives in `openeire_api.pdf_markdown` and returns ReportLab flowables from supported Markdown blocks.

Document-specific modules remain responsible for:
- loading templates
- replacing placeholders
- building filenames
- setting PDF metadata
- deciding when PDFs are generated or attached

Real estate booking agreements are generated statelessly at email-send time from `realestate/docs/booking_agreement.md`.

## Migration Status

No migrations required.

No model changes were made.

## Tests

Passed:

```
.venv\Scripts\python.exe -m compileall openeire_api\pdf_markdown.py products\pdf_generator.py products\personal_licence.py realestate\documents.py realestate\admin.py realestate\tests.py products\tests.py
.venv\Scripts\python.exe manage.py test realestate products.tests.LicenseRequestTests.test_personal_licence_pdf_uses_shared_markdown_renderer
.venv\Scripts\python.exe manage.py test products
```

## Notes

The booking agreement Markdown is editable and wired into the workflow, but the agreement wording should still get a final legal/commercial review before production use.