### PR TITLE
Automate real estate deposit checkout flow

### DIFF
--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -36,6 +36,7 @@ from products.models import (
     PersonalDownloadToken,
     generate_variants_for_photo,
 )
+from realestate.models import RealEstateEnquiry
 from .discounts import record_discount_redemption
 from .attempts import canonicalize_cart
 from .models import CheckoutAttempt, DiscountRedemption, Order, OrderItem, ProductShipping
@@ -828,6 +829,189 @@ class StripeWebhookLicenseTests(TestCase):
         event = StripeWebhookEvent.objects.get(stripe_event_id="evt_missing_asset")
         self.assertEqual(event.status, "FAILED")
         self.assertIn("Deliverable asset file", event.error_message)
+
+    @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_realestate_deposit_checkout_marks_enquiry_paid(self, mock_construct):
+        enquiry = RealEstateEnquiry.objects.create(
+            name="Jane Agent",
+            email="jane@example.com",
+            phone="+353 87 123 4567",
+            company_name="Example Estate Agents",
+            client_type=RealEstateEnquiry.ClientType.ESTATE_AGENT,
+            property_address="Example House, Salthill, Galway",
+            county="Galway",
+            eircode="H91 XXXX",
+            property_type="Detached house",
+            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            preferred_date="2026-06-20",
+            shoot_date="2026-06-22",
+            quoted_price="399.00",
+            booking_agreement_received=True,
+            deposit_payment_link="https://checkout.stripe.com/c/pay/realestate",
+            stripe_deposit_session_id="cs_realestate_deposit",
+            status=RealEstateEnquiry.Status.QUOTED,
+            consent_to_contact=True,
+        )
+        mock_construct.return_value = {
+            "id": "evt_realestate_deposit",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "id": "cs_realestate_deposit",
+                    "payment_status": "paid",
+                    "payment_intent": "pi_realestate_deposit",
+                    "amount_total": 14723,
+                    "currency": "eur",
+                    "metadata": {
+                        "purpose": "realestate_deposit",
+                        "realestate_enquiry_id": str(enquiry.pk),
+                        "client_name": "Jane Agent",
+                        "property_address": "Example House, Salthill, Galway",
+                        "package_name": "Pro",
+                    },
+                }
+            },
+        }
+
+        response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        enquiry.refresh_from_db()
+        self.assertTrue(enquiry.deposit_paid)
+        self.assertIsNotNone(enquiry.deposit_paid_at)
+        self.assertEqual(enquiry.status, RealEstateEnquiry.Status.BOOKED)
+        self.license_request.refresh_from_db()
+        self.assertEqual(self.license_request.status, "PAYMENT_PENDING")
+        self.assertEqual(len(mail.outbox), 0)
+
+    def _create_realestate_deposit_enquiry(self):
+        return RealEstateEnquiry.objects.create(
+            name="Jane Agent",
+            email="jane@example.com",
+            phone="+353 87 123 4567",
+            company_name="Example Estate Agents",
+            client_type=RealEstateEnquiry.ClientType.ESTATE_AGENT,
+            property_address="Example House, Salthill, Galway",
+            county="Galway",
+            eircode="H91 XXXX",
+            property_type="Detached house",
+            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            preferred_date="2026-06-20",
+            shoot_date="2026-06-22",
+            quoted_price="399.00",
+            booking_agreement_received=True,
+            deposit_payment_link="https://checkout.stripe.com/c/pay/realestate",
+            stripe_deposit_session_id="cs_realestate_deposit",
+            status=RealEstateEnquiry.Status.QUOTED,
+            consent_to_contact=True,
+        )
+
+    def _realestate_deposit_event(self, enquiry, *, event_id, **session_overrides):
+        session = {
+            "id": "cs_realestate_deposit",
+            "payment_status": "paid",
+            "payment_intent": "pi_realestate_deposit",
+            "amount_total": 14723,
+            "currency": "eur",
+            "metadata": {
+                "purpose": "realestate_deposit",
+                "realestate_enquiry_id": str(enquiry.pk),
+                "client_name": "Jane Agent",
+                "property_address": "Example House, Salthill, Galway",
+                "package_name": "Pro",
+            },
+        }
+        session.update(session_overrides)
+        return {
+            "id": event_id,
+            "type": "checkout.session.completed",
+            "data": {"object": session},
+        }
+
+    @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_realestate_deposit_webhook_fails_on_session_mismatch(self, mock_construct):
+        enquiry = self._create_realestate_deposit_enquiry()
+        mock_construct.return_value = self._realestate_deposit_event(
+            enquiry,
+            event_id="evt_realestate_session_mismatch",
+            id="cs_wrong_session",
+        )
+
+        response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 500)
+        enquiry.refresh_from_db()
+        self.assertFalse(enquiry.deposit_paid)
+        self.assertEqual(enquiry.status, RealEstateEnquiry.Status.QUOTED)
+        event = StripeWebhookEvent.objects.get(
+            stripe_event_id="evt_realestate_session_mismatch"
+        )
+        self.assertEqual(event.status, "FAILED")
+        self.assertIn("stored enquiry session", event.error_message)
+
+    @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_realestate_deposit_webhook_fails_on_amount_mismatch(self, mock_construct):
+        enquiry = self._create_realestate_deposit_enquiry()
+        mock_construct.return_value = self._realestate_deposit_event(
+            enquiry,
+            event_id="evt_realestate_amount_mismatch",
+            amount_total=100,
+        )
+
+        response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 500)
+        enquiry.refresh_from_db()
+        self.assertFalse(enquiry.deposit_paid)
+        self.assertEqual(enquiry.status, RealEstateEnquiry.Status.QUOTED)
+        event = StripeWebhookEvent.objects.get(
+            stripe_event_id="evt_realestate_amount_mismatch"
+        )
+        self.assertEqual(event.status, "FAILED")
+        self.assertIn("expected booking deposit", event.error_message)
+
+    @patch("checkout.views.stripe.Webhook.construct_event")
+    def test_realestate_deposit_webhook_fails_when_enquiry_metadata_missing(
+        self,
+        mock_construct,
+    ):
+        enquiry = self._create_realestate_deposit_enquiry()
+        mock_construct.return_value = self._realestate_deposit_event(
+            enquiry,
+            event_id="evt_realestate_missing_enquiry",
+            metadata={"purpose": "realestate_deposit"},
+        )
+
+        response = self.client.post(
+            self.url,
+            data="{}",
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 500)
+        enquiry.refresh_from_db()
+        self.assertFalse(enquiry.deposit_paid)
+        event = StripeWebhookEvent.objects.get(
+            stripe_event_id="evt_realestate_missing_enquiry"
+        )
+        self.assertEqual(event.status, "FAILED")
+        self.assertIn("realestate_enquiry_id", event.error_message)
 
 
 @override_settings(

--- a/checkout/views.py
+++ b/checkout/views.py
@@ -35,6 +35,8 @@ from products.licensing import (
 from products.file_access import asset_file_exists, get_asset_file_name, open_asset_file
 from products.personal_downloads import ensure_personal_download_token
 from products.personal_licence import get_personal_terms_version
+from realestate.models import RealEstateEnquiry
+from realestate.payments import calculate_realestate_deposit_amounts
 from userprofiles.models import UserProfile
 from .attempts import (
     build_request_fingerprint,
@@ -880,6 +882,94 @@ class StripeWebhookView(APIView):
             license_request.id,
         )
 
+    def _handle_realestate_deposit_payment(self, session):
+        metadata = session.get('metadata') or {}
+        if metadata.get('purpose') != 'realestate_deposit':
+            return False
+
+        payment_status = session.get('payment_status')
+        if payment_status != 'paid':
+            logger.warning(
+                "Real estate deposit checkout session not paid yet (status=%s). Skipping. session_id=%s",
+                payment_status,
+                session.get('id') or "unknown",
+            )
+            return True
+
+        checkout_session_id = str(session.get('id') or "").strip()
+        enquiry_id = str(metadata.get('realestate_enquiry_id') or "").strip()
+        if not enquiry_id:
+            raise RuntimeError(
+                "Paid real estate deposit checkout session is missing "
+                "realestate_enquiry_id metadata."
+            )
+
+        enquiry = (
+            RealEstateEnquiry.objects
+            .select_for_update()
+            .filter(pk=enquiry_id)
+            .first()
+        )
+        if enquiry is None:
+            raise RuntimeError(
+                "Paid real estate deposit checkout session referenced "
+                f"unknown enquiry {enquiry_id}."
+            )
+
+        stored_session_id = str(enquiry.stripe_deposit_session_id or "").strip()
+        if stored_session_id and checkout_session_id != stored_session_id:
+            raise RuntimeError(
+                "Paid real estate deposit checkout session did not match "
+                "the stored enquiry session."
+            )
+
+        expected_amount_cents = int(
+            (
+                calculate_realestate_deposit_amounts(enquiry)["deposit_amount"]
+                * Decimal("100")
+            ).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+        )
+        amount_total = int(session.get('amount_total') or 0)
+        currency = str(session.get('currency') or "").lower()
+        if amount_total != expected_amount_cents or currency != "eur":
+            raise RuntimeError(
+                "Paid real estate deposit amount did not match the "
+                "expected booking deposit."
+            )
+
+        if enquiry.deposit_paid:
+            logger.info(
+                "Real estate deposit already marked paid; skipping. enquiry_id=%s",
+                enquiry.pk,
+            )
+            return True
+
+        paid_at = timezone.now()
+        update_fields = ["deposit_paid", "deposit_paid_at", "updated_at"]
+        enquiry.deposit_paid = True
+        enquiry.deposit_paid_at = paid_at
+
+        if checkout_session_id and not enquiry.stripe_deposit_session_id:
+            enquiry.stripe_deposit_session_id = checkout_session_id
+            update_fields.append("stripe_deposit_session_id")
+
+        if enquiry.status not in {
+            RealEstateEnquiry.Status.BOOKED,
+            RealEstateEnquiry.Status.COMPLETED,
+            RealEstateEnquiry.Status.CLOSED,
+            RealEstateEnquiry.Status.SPAM,
+        }:
+            enquiry.status = RealEstateEnquiry.Status.BOOKED
+            update_fields.append("status")
+
+        enquiry.save(update_fields=update_fields)
+        logger.info(
+            "Real estate deposit marked paid. enquiry_id=%s session_id=%s",
+            enquiry.pk,
+            checkout_session_id or "unknown",
+        )
+        return True
+
     def post(self, request):
         stripe.api_key = settings.STRIPE_SECRET_KEY
         webhook_secret = settings.STRIPE_WEBHOOK_SECRET
@@ -1367,7 +1457,10 @@ class StripeWebhookView(APIView):
 
             elif event_type == 'checkout.session.completed':
                 session = event['data']['object']
-                self._handle_license_payment(request, session)
+                with transaction.atomic():
+                    handled_realestate_deposit = self._handle_realestate_deposit_payment(session)
+                if not handled_realestate_deposit:
+                    self._handle_license_payment(request, session)
         except DRFValidationError as e:
             processing_error = str(e.detail if hasattr(e, "detail") else e)
             # A signed, successful PaymentIntent backed by a checkout snapshot

--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -9,6 +9,8 @@ from .emails import send_templated_email
 from .documents import build_booking_agreement_filename
 from .documents import generate_booking_agreement_pdf
 from .models import RealEstateEnquiry
+from .payments import calculate_realestate_deposit_amounts
+from .payments import create_realestate_deposit_checkout_session
 
 
 @admin.register(RealEstateEnquiry, site=custom_admin_site)
@@ -24,6 +26,7 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
         "quoted_price",
         "shoot_date",
         "booking_agreement_received",
+        "deposit_paid",
     )
     list_filter = (
         "status",
@@ -41,7 +44,12 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
         "property_address",
         "eircode",
     )
-    readonly_fields = ("created_at", "updated_at")
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+        "stripe_deposit_session_id",
+        "deposit_paid_at",
+    )
     actions = (
         "send_quote_email",
         "send_booking_agreement_email",
@@ -107,6 +115,9 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
                     "booking_agreement_link",
                     "booking_agreement_received",
                     "deposit_payment_link",
+                    "stripe_deposit_session_id",
+                    "deposit_paid",
+                    "deposit_paid_at",
                     "delivery_link",
                     "review_link",
                 )
@@ -146,6 +157,11 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
             "delivery_link": enquiry.delivery_link,
             "review_link": enquiry.review_link,
         }
+        if enquiry.quoted_price is not None:
+            try:
+                context.update(calculate_realestate_deposit_amounts(enquiry))
+            except ValueError:
+                pass
         return context
 
     def _send_email_action(
@@ -275,17 +291,79 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
 
     @admin.action(description="Send deposit request email")
     def send_deposit_request_email(self, request, queryset):
-        self._send_email_action(
-            request,
-            queryset,
-            subject="Booking deposit request - OpenEire Studios",
-            template_base="deposit_request",
-            description="Deposit request email",
-            required_context=lambda enquiry, context: [
-                ("deposit payment link", context.get("deposit_payment_link")),
-                ("signed booking agreement received", getattr(enquiry, "booking_agreement_received", False)),
-            ],
-        )
+        sent_count = 0
+        failed_count = 0
+        skipped_count = 0
+        warnings = []
+
+        for enquiry in queryset:
+            email = str(getattr(enquiry, "email", "") or "").strip()
+            if not email:
+                skipped_count += 1
+                warnings.append(f"{enquiry}: skipped because no client email is available.")
+                continue
+            if not getattr(enquiry, "booking_agreement_received", False):
+                skipped_count += 1
+                warnings.append(
+                    f"{enquiry}: skipped because signed booking agreement received is missing."
+                )
+                continue
+            if enquiry.quoted_price is None:
+                skipped_count += 1
+                warnings.append(f"{enquiry}: skipped because quoted price is missing.")
+                continue
+
+            context = self._build_base_context(enquiry)
+            if not context.get("deposit_payment_link"):
+                try:
+                    context["deposit_payment_link"] = create_realestate_deposit_checkout_session(
+                        enquiry
+                    )
+                except Exception as exc:
+                    failed_count += 1
+                    warnings.append(
+                        f"{enquiry}: deposit checkout creation failed ({exc.__class__.__name__}: {exc})."
+                    )
+                    continue
+
+            try:
+                send_templated_email(
+                    subject="Booking deposit request - OpenEire Studios",
+                    to=[email],
+                    template_base="deposit_request",
+                    context=build_realestate_email_context(enquiry, **context),
+                    reply_to=self._get_reply_to(),
+                )
+                sent_count += 1
+            except Exception as exc:
+                failed_count += 1
+                warnings.append(
+                    f"{enquiry}: deposit request email failed ({exc.__class__.__name__}: {exc})."
+                )
+
+        if sent_count:
+            self.message_user(
+                request,
+                f"Deposit request email sent for {sent_count} enquiry(s).",
+                level=messages.SUCCESS,
+            )
+        if skipped_count:
+            self.message_user(
+                request,
+                f"Skipped {skipped_count} enquiry(s) because required data was missing.",
+                level=messages.WARNING,
+            )
+        if failed_count:
+            self.message_user(
+                request,
+                f"Deposit request email failed for {failed_count} enquiry(s).",
+                level=messages.ERROR,
+            )
+        if warnings:
+            preview = "; ".join(warnings[:3])
+            if len(warnings) > 3:
+                preview = f"{preview}; plus {len(warnings) - 3} more."
+            self.message_user(request, preview, level=messages.WARNING)
 
     @admin.action(description="Send confirmation email")
     def send_confirmation_email(self, request, queryset):

--- a/realestate/docs/booking_agreement.md
+++ b/realestate/docs/booking_agreement.md
@@ -1,99 +1,156 @@
-# OpenEire Studios Real Estate Booking Agreement
+# OpenEire Real Estate Media Booking Agreement
 
 Booking reference: **{{ booking_reference }}**  
 Issued on: **{{ issued_on }}**
+
+This Booking Agreement forms part of the Agreement between OpenEire Studios (OpenEire) and the Client for the provision of real estate media services. It should be read together with the OpenEire Property Media Service Terms, which set out the core legal terms governing property photography, videography, drone operations, licensing, payment, liability, and cancellation.
+
+Drone operations in Europe are governed under the EASA framework, including Regulation (EU) 2019/947, and are administered in Ireland by the Irish Aviation Authority.
 
 ---
 
 ## 1. Parties
 
-**Client:** {{ client_name }}  
-**Company / agency:** {{ company_name }}  
+This Booking Agreement is entered into between:
+
+**OpenEire Studios**  
+7A The Crescent, Loughrea  
+studio@openeire.ie
+
+and
+
+**Client name:** {{ client_name }}  
+**Agency / business name:** {{ company_name }}  
+**Contact name:** {{ client_contact_name }}  
 **Email:** {{ email }}  
-**Phone:** {{ phone }}
-
-**Supplier:** OpenEire Studios
-
----
-
-## 2. Booking Details
-
-| Item | Details |
-| --- | --- |
-| Property | {{ property_address }} |
-| Property type | {{ property_type }} |
-| Package | {{ package_name }} |
-| Add-ons | {{ add_ons_summary }} |
-| Proposed shoot date | {{ shoot_date }} |
-| Quote total excluding VAT | {{ quote_total }} |
+**Telephone:** {{ phone }}  
+**Registered / business address:** {{ registered_business_address }}
 
 ---
 
-## 3. Scope
+## 2. Property and Booking Details
 
-OpenEire Studios will provide property media services for the property listed above, based on the package and add-ons agreed with the client.
-
-The final deliverables, timing, and access requirements remain subject to weather, safe drone operation, property readiness, permissions, and any written changes agreed before the shoot.
-
----
-
-## 4. Client Responsibilities
-
-The client agrees to:
-
-- Ensure the property is ready for photography, video, drone, or virtual tour work before the scheduled appointment.
-- Confirm that access is available at the agreed time.
-- Obtain any required owner, occupier, management company, or neighbour permissions.
-- Notify OpenEire Studios of access restrictions, hazards, alarms, pets, parking issues, or sensitive areas before the shoot.
-- Ensure any people, vehicles, confidential documents, or personal items that should not appear in media are removed or identified before capture begins.
+**Property address:** {{ property_address }}  
+**Property type:** {{ property_type }}  
+**Listing type:** {{ listing_type }}  
+**Shoot date:** {{ shoot_date }}  
+**Shoot time:** {{ shoot_time }}  
+**Access contact on site:** {{ access_contact }}  
+**Access notes / restrictions:** {{ access_notes }}  
+**Drone services included:** Subject to the selected package, agreed add-ons, legal conditions, weather, safety, and operational restrictions on the day  
+**Travel supplement applies:** If agreed in writing before the shoot  
+**Travel details:** {{ travel_details }}
 
 ---
 
-## 5. Booking Status and Deposit
+## 3. Selected Package and Included Services
 
-The booking remains provisional until:
+The Client books the following package:
 
-1. This Booking Agreement has been signed and returned.
-2. The required booking deposit has been received in cleared funds.
+**Package name:** {{ package_name }}  
+**Package fee excluding VAT:** {{ quote_total }}  
+**VAT:** {{ vat_total }}  
+**Total fee including VAT:** {{ total_including_vat }}  
+**Deposit required:** {{ deposit_amount }}  
+**Balance due on delivery:** {{ balance_due }}
 
-The Deposit Request email will be issued separately after the signed Booking Agreement has been received.
+Included Deliverables:
 
----
+- The deliverables included in the selected package listed above.
+- Any additional agreed add-ons listed below.
+- Professionally edited property media suitable for marketing the property identified in this Booking Agreement.
+- Any drone, video, social media, floor plan, virtual tour, or additional media outputs only where expressly included in the package or agreed in writing.
 
-## 6. Weather, Drone, and Rescheduling
+Additional Agreed Add-Ons:
 
-Drone and exterior media are subject to weather, daylight, airspace, safety, and legal operating conditions.
+- {{ add_ons_summary }}
 
-If weather or site conditions prevent safe or suitable capture, OpenEire Studios may reschedule the affected part of the shoot or agree an alternative delivery approach with the client.
-
----
-
-## 7. Delivery and Usage
-
-Delivered media may be used by the client for marketing the property identified in this agreement, including property portals, agency websites, printed brochures, and social media connected with that listing.
-
-Media must not be resold, relicensed, transferred to unrelated third parties, or used for unrelated properties, campaigns, or stock/media libraries without written permission from OpenEire Studios.
-
----
-
-## 8. Cancellation and Changes
-
-Please provide as much notice as possible if the shoot needs to be changed or cancelled.
-
-OpenEire Studios may charge reasonable costs for late cancellations, failed access, or material scope changes where time or travel has already been committed.
+Only the Deliverables expressly listed above are included in this Booking Agreement. RAW files, source files, unedited footage, and any services not expressly listed are excluded unless separately agreed in writing.
 
 ---
 
-## 9. Acceptance
+## 4. Fee, Deposit and Payment Terms
 
-By signing and returning this agreement, the client confirms that the booking details are accurate and that they accept the booking terms above.
+4.1 The Client shall pay a booking deposit equal to 30% of the Total Fee in order to secure the booking.
 
-Client signature: ______________________________
+4.2 The proposed Shoot Date and Shoot Time are reserved provisionally. The booking is not confirmed until OpenEire has received both the signed Booking Agreement and the booking deposit in cleared funds. Until confirmation, OpenEire reserves the right to release the proposed booking slot to another client.
 
-Name: {{ client_name }}
+4.3 The remaining balance shall be due on the day of delivery of the Deliverables.
 
+4.4 OpenEire may withhold delivery of the Deliverables until 100% of the Total Fee and any other sums due have been paid in full.
+
+4.5 No licence shall take effect until all sums due have been paid in full.
+
+4.6 Any additional work, amendments, extra travel, waiting time, extended attendance, additional outputs, or post-booking scope changes requested by the Client may be charged separately at OpenEire's then-current rates.
+
+---
+
+## 5. Cancellation and Rescheduling
+
+5.1 If the Client cancels the booking more than 72 hours before the Shoot Date, the deposit shall be retained by OpenEire and no further fee shall be due.
+
+5.2 If the Client cancels the booking between 24 and 72 hours before the Shoot Date, 50% of the Total Fee shall be payable by the Client, less any deposit already paid.
+
+5.3 If the Client cancels the booking less than 24 hours before the Shoot Date, or if OpenEire attends the Property and cannot reasonably perform the Services due to lack of access, inaccurate instructions, an unready site, or other Client-side failure, 100% of the Total Fee shall be payable.
+
+5.4 OpenEire shall permit one reschedule without additional rescheduling charge where OpenEire reasonably determines that weather conditions, safety concerns, or legal or operational restrictions make the Services unsuitable to proceed on the Shoot Date.
+
+5.5 Any further reschedule, or any reschedule requested by the Client, may be charged at OpenEire's then-current rates and shall be subject to availability.
+
+5.6 A material change to the Property, scope, date, time, or access arrangements may be treated by OpenEire as a cancellation and rebooking.
+
+---
+
+## 6. Delivery and Editing
+
+6.1 OpenEire shall use reasonable endeavours to deliver the Deliverables within 24 hours of the Shoot Date.
+
+6.2 The Client acknowledges that delivery within 24 hours is conditional upon lawful and safe operating conditions, property access, weather, technical issues, and events outside OpenEire's reasonable control.
+
+6.3 Deliverables shall be supplied in OpenEire's standard professional editing style.
+
+6.4 No subjective revision rounds are included.
+
+6.5 Any obvious technical defect or material deviation from the agreed scope must be notified within 24 hours of delivery, following which OpenEire may, at its discretion, correct the issue.
+
+---
+
+## 7. Client Acknowledgements
+
+7.1 The Client acknowledges and agrees that:
+
+- The licence granted for the Deliverables is limited to the marketing of the specific property identified in this Booking Agreement.
+- Where the Client is a private property owner, the Client may permit one appointed estate agent/auctioneer acting on their behalf to use the Deliverables solely for marketing the same property listing, subject to these Terms.
+- The licence is non-exclusive, non-transferable except as expressly permitted above, does not transfer ownership of any Deliverable to the Client, and may not be reused for any other property, development, marketing campaign, or instruction.
+- The licence ends immediately when the Property is sold, let, withdrawn from the market, or the relevant marketing instruction otherwise ends.
+- RAW files and unedited source material are excluded.
+- Drone capture is subject to legal, regulatory, and safety conditions on the day.
+- OpenEire may rely on the Client's permissions, instructions, and warranties regarding access and authority to instruct the Services.
+
+---
+
+## 8. Incorporation of Service Terms
+
+8.1 This Booking Agreement incorporates and is subject to the OpenEire Property Media Service Terms, which together form the entire agreement between the parties for the relevant booking.
+
+8.2 In the event of any inconsistency between this Booking Agreement and the OpenEire Property Media Service Terms, this Booking Agreement shall prevail to the extent of that inconsistency for the specific booking details and commercial terms only.
+
+---
+
+## 9. Signatures and Acceptance
+
+Signed electronically for and on behalf of OpenEire Studios
+
+Name: Gerard Deely  
+Title: OpenEire Studios  
+Date: {{ issued_on }}
+
+Signed by or on behalf of the Client:
+
+Name: ______________________________  
+Title: ______________________________  
 Date: ______________________________
 
-OpenEire Studios signature: ______________________________
+By signing electronically and by paying the booking deposit after receipt of this Booking Agreement, the Client confirms that it has read, understood, and agreed to this Booking Agreement and the OpenEire Property Media Service Terms.
 
-Date: ______________________________
+The booking shall not be confirmed until both the signed Booking Agreement and the booking deposit have been received by OpenEire.

--- a/realestate/documents.py
+++ b/realestate/documents.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.utils.text import slugify
 
 from openeire_api.pdf_markdown import render_markdown_to_flowables
+from .payments import calculate_realestate_deposit_amounts
 
 from reportlab.lib.pagesizes import A4
 from reportlab.platypus import SimpleDocTemplate
@@ -16,6 +17,16 @@ from reportlab.platypus import SimpleDocTemplate
 BOOKING_AGREEMENT_TEMPLATE_PATH = (
     Path(__file__).resolve().parent / "docs" / "booking_agreement.md"
 )
+BOOKING_AGREEMENT_BLANK = "______________________________"
+
+
+def blank_if_missing(value, blank=BOOKING_AGREEMENT_BLANK):
+    if value is None:
+        return blank
+    text = str(value).strip()
+    if not text:
+        return blank
+    return xml_escape(text)
 
 
 def _safe_value(value, default="Not specified"):
@@ -41,6 +52,20 @@ def _format_money(value):
     return f"EUR {value}"
 
 
+def _format_agreement_date(value):
+    if not value:
+        return BOOKING_AGREEMENT_BLANK
+    if isinstance(value, str):
+        return blank_if_missing(value)
+    return value.strftime("%d %B %Y")
+
+
+def _format_agreement_money(value):
+    if value is None:
+        return BOOKING_AGREEMENT_BLANK
+    return f"EUR {value}"
+
+
 def _booking_reference(enquiry):
     return f"RE-{enquiry.id}" if getattr(enquiry, "id", None) else "RE-DRAFT"
 
@@ -62,37 +87,57 @@ def _load_booking_agreement_template():
 
 
 def _build_booking_agreement_context(enquiry):
-    property_address = _safe_value(getattr(enquiry, "property_address", ""))
-    county = _safe_value(getattr(enquiry, "county", ""), default="")
+    property_address = blank_if_missing(getattr(enquiry, "property_address", ""))
+    county = blank_if_missing(getattr(enquiry, "county", ""), blank="")
     if county:
         property_address = f"{property_address}, {county}"
+
+    quote_amounts = {}
+    try:
+        quote_amounts = calculate_realestate_deposit_amounts(enquiry)
+    except ValueError:
+        quote_amounts = {}
+
+    quote_total = quote_amounts.get("quote_total", getattr(enquiry, "quoted_price", None))
 
     return {
         "booking_reference": _booking_reference(enquiry),
         "issued_on": timezone.localdate().strftime("%d %B %Y"),
-        "client_name": _safe_value(getattr(enquiry, "name", "")),
-        "company_name": _safe_value(getattr(enquiry, "company_name", ""), default="Not provided"),
-        "email": _safe_value(getattr(enquiry, "email", "")),
-        "phone": _safe_value(getattr(enquiry, "phone", "")),
+        "client_name": blank_if_missing(getattr(enquiry, "name", "")),
+        "company_name": blank_if_missing(getattr(enquiry, "company_name", "")),
+        "client_contact_name": blank_if_missing(getattr(enquiry, "name", "")),
+        "email": blank_if_missing(getattr(enquiry, "email", "")),
+        "phone": blank_if_missing(getattr(enquiry, "phone", "")),
+        "registered_business_address": BOOKING_AGREEMENT_BLANK,
         "property_address": property_address,
-        "property_type": _safe_value(getattr(enquiry, "property_type", "")),
-        "package_name": _safe_value(
-            enquiry.get_preferred_package_summary()
-            if hasattr(enquiry, "get_preferred_package_summary")
-            else getattr(enquiry, "preferred_package", "")
-        ),
-        "add_ons_summary": _safe_value(
-            enquiry.get_add_ons_summary()
-            if hasattr(enquiry, "get_add_ons_summary")
-            else "",
-            default="None",
-        ),
-        "shoot_date": _format_date(
+        "property_type": blank_if_missing(getattr(enquiry, "property_type", "")),
+        "listing_type": BOOKING_AGREEMENT_BLANK,
+        "shoot_date": _format_agreement_date(
             getattr(enquiry, "shoot_date", None)
             or getattr(enquiry, "preferred_date", None)
             or getattr(enquiry, "proposed_shoot_date", None)
         ),
-        "quote_total": _format_money(getattr(enquiry, "quoted_price", None)),
+        "shoot_time": BOOKING_AGREEMENT_BLANK,
+        "access_contact": BOOKING_AGREEMENT_BLANK,
+        "access_notes": BOOKING_AGREEMENT_BLANK,
+        "travel_details": BOOKING_AGREEMENT_BLANK,
+        "package_name": blank_if_missing(
+            enquiry.get_preferred_package_summary()
+            if hasattr(enquiry, "get_preferred_package_summary")
+            else getattr(enquiry, "preferred_package", "")
+        ),
+        "add_ons_summary": blank_if_missing(
+            enquiry.get_add_ons_summary()
+            if hasattr(enquiry, "get_add_ons_summary")
+            else ""
+        ),
+        "quote_total": _format_agreement_money(quote_total),
+        "vat_total": _format_agreement_money(quote_amounts.get("vat_total")),
+        "total_including_vat": _format_agreement_money(
+            quote_amounts.get("total_including_vat")
+        ),
+        "deposit_amount": _format_agreement_money(quote_amounts.get("deposit_amount")),
+        "balance_due": _format_agreement_money(quote_amounts.get("balance_due")),
     }
 
 

--- a/realestate/migrations/0004_realestateenquiry_deposit_payment_state.py
+++ b/realestate/migrations/0004_realestateenquiry_deposit_payment_state.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("realestate", "0003_realestateenquiry_client_links_and_booking_state"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="realestateenquiry",
+            name="deposit_payment_link",
+            field=models.URLField(blank=True, max_length=500),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="deposit_paid",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="deposit_paid_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="stripe_deposit_session_id",
+            field=models.CharField(blank=True, max_length=255),
+        ),
+    ]

--- a/realestate/models.py
+++ b/realestate/models.py
@@ -81,7 +81,10 @@ class RealEstateEnquiry(models.Model):
 
     proposed_shoot_date = models.DateField(null=True, blank=True)
     booking_agreement_received = models.BooleanField(default=False)
-    deposit_payment_link = models.URLField(blank=True)
+    deposit_payment_link = models.URLField(max_length=500, blank=True)
+    stripe_deposit_session_id = models.CharField(max_length=255, blank=True)
+    deposit_paid = models.BooleanField(default=False)
+    deposit_paid_at = models.DateTimeField(null=True, blank=True)
     booking_agreement_link = models.URLField(blank=True)
     delivery_link = models.URLField(blank=True)
     review_link = models.URLField(blank=True)

--- a/realestate/payments.py
+++ b/realestate/payments.py
@@ -1,0 +1,150 @@
+import logging
+from decimal import Decimal
+from decimal import ROUND_HALF_UP
+from urllib.parse import urljoin
+
+import stripe
+from django.conf import settings
+
+from .emails import get_realestate_site_url
+
+
+logger = logging.getLogger(__name__)
+
+VAT_RATE = Decimal("0.23")
+DEPOSIT_RATE = Decimal("0.30")
+
+
+def _money(value):
+    return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def calculate_realestate_deposit_amounts(enquiry):
+    if getattr(enquiry, "quoted_price", None) is None:
+        raise ValueError("Quoted price is required before creating a deposit checkout.")
+
+    quote_total = _money(enquiry.quoted_price)
+    if quote_total <= 0:
+        raise ValueError("Quoted price must be greater than zero.")
+
+    vat_total = _money(quote_total * VAT_RATE)
+    total_including_vat = _money(quote_total + vat_total)
+    deposit_amount = _money(total_including_vat * DEPOSIT_RATE)
+    balance_due = _money(total_including_vat - deposit_amount)
+
+    return {
+        "quote_total": quote_total,
+        "vat_total": vat_total,
+        "total_including_vat": total_including_vat,
+        "deposit_amount": deposit_amount,
+        "balance_due": balance_due,
+    }
+
+
+def _configured_stripe_payment_method_types():
+    configured = getattr(settings, "STRIPE_PAYMENT_METHOD_TYPES", None)
+    if isinstance(configured, (list, tuple)):
+        cleaned = [
+            value.strip()
+            for value in configured
+            if isinstance(value, str) and value.strip()
+        ]
+        if cleaned:
+            return cleaned
+    return ["card"]
+
+
+def _checkout_return_url(path):
+    return urljoin(get_realestate_site_url().rstrip("/") + "/", path.lstrip("/"))
+
+
+def _stripe_metadata(enquiry):
+    return {
+        "realestate_enquiry_id": str(enquiry.pk),
+        "client_name": str(getattr(enquiry, "name", "") or "")[:500],
+        "property_address": str(getattr(enquiry, "property_address", "") or "")[:500],
+        "package_name": (
+            enquiry.get_preferred_package_display()
+            if hasattr(enquiry, "get_preferred_package_display")
+            else str(getattr(enquiry, "preferred_package", "") or "")
+        )[:500],
+        "purpose": "realestate_deposit",
+    }
+
+
+def create_realestate_deposit_checkout_session(enquiry):
+    if not getattr(enquiry, "pk", None):
+        raise ValueError("Enquiry must be saved before creating a deposit checkout.")
+
+    amounts = calculate_realestate_deposit_amounts(enquiry)
+    amount_in_cents = int(
+        (amounts["deposit_amount"] * Decimal("100")).quantize(
+            Decimal("1"),
+            rounding=ROUND_HALF_UP,
+        )
+    )
+    if amount_in_cents <= 0:
+        raise ValueError("Deposit amount must be greater than zero.")
+
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+    stripe.max_network_retries = getattr(settings, "STRIPE_MAX_NETWORK_RETRIES", 2)
+    stripe.default_http_client = stripe.RequestsClient(
+        timeout=getattr(settings, "STRIPE_TIMEOUT_SECONDS", 10)
+    )
+
+    metadata = _stripe_metadata(enquiry)
+    session_kwargs = {
+        "mode": "payment",
+        "payment_method_types": _configured_stripe_payment_method_types(),
+        "line_items": [
+            {
+                "price_data": {
+                    "currency": "eur",
+                    "unit_amount": amount_in_cents,
+                    "product_data": {
+                        "name": f"OpenEire real estate booking deposit - RE-{enquiry.pk}",
+                        "metadata": metadata,
+                    },
+                },
+                "quantity": 1,
+            }
+        ],
+        "metadata": metadata,
+        "payment_intent_data": {"metadata": metadata},
+        "success_url": _checkout_return_url(
+            "real-estate/deposit/success?session_id={CHECKOUT_SESSION_ID}"
+        ),
+        "cancel_url": _checkout_return_url("real-estate/deposit/cancelled"),
+    }
+    customer_email = str(getattr(enquiry, "email", "") or "").strip()
+    if customer_email:
+        session_kwargs["customer_email"] = customer_email
+
+    session = stripe.checkout.Session.create(
+        **session_kwargs,
+        idempotency_key=f"realestate-deposit-enquiry-{enquiry.pk}-{amount_in_cents}",
+    )
+
+    checkout_url = str(getattr(session, "url", "") or session.get("url", "")).strip()
+    session_id = str(getattr(session, "id", "") or session.get("id", "")).strip()
+    if not checkout_url:
+        raise RuntimeError("Stripe did not return a checkout URL.")
+
+    enquiry.deposit_payment_link = checkout_url
+    if session_id:
+        enquiry.stripe_deposit_session_id = session_id
+    enquiry.save(
+        update_fields=[
+            "deposit_payment_link",
+            "stripe_deposit_session_id",
+            "updated_at",
+        ]
+    )
+
+    logger.info(
+        "Created real estate deposit checkout session. enquiry_id=%s session_id=%s amount_cents=%s",
+        enquiry.pk,
+        session_id or "unknown",
+        amount_in_cents,
+    )
+    return checkout_url

--- a/realestate/tests.py
+++ b/realestate/tests.py
@@ -16,6 +16,8 @@ from openeire_api.pdf_markdown import render_markdown_to_flowables
 
 from .admin import RealEstateEnquiryAdmin
 from .documents import build_booking_agreement_filename
+from .documents import _build_booking_agreement_context
+from .documents import _load_booking_agreement_template
 from .documents import generate_booking_agreement_pdf
 from .emails import build_realestate_email_context
 from .emails import format_money
@@ -398,6 +400,13 @@ class MarkdownPDFRendererTests(SimpleTestCase):
 
 
 class BookingAgreementDocumentTests(TestCase):
+    def _render_booking_agreement_markdown(self, enquiry):
+        from django.template import Context, Template
+
+        return Template(_load_booking_agreement_template()).render(
+            Context(_build_booking_agreement_context(enquiry), autoescape=False)
+        )
+
     def test_booking_agreement_pdf_generation_returns_pdf(self):
         enquiry = RealEstateEnquiry.objects.create(
             name="Jane Agent",
@@ -422,6 +431,76 @@ class BookingAgreementDocumentTests(TestCase):
         self.assertEqual(
             build_booking_agreement_filename(enquiry),
             f"openeire-booking-agreement-re-{enquiry.id}-jane-agent.pdf",
+        )
+
+    def test_booking_agreement_missing_optional_fields_render_as_blank_lines(self):
+        enquiry = RealEstateEnquiry.objects.create(
+            name="Jane Agent",
+            email="jane@example.com",
+            phone="+353 87 123 4567",
+            client_type=RealEstateEnquiry.ClientType.PRIVATE_SELLER,
+            property_address="Example House, Salthill",
+            county="Galway",
+            property_type="Detached house",
+            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            consent_to_contact=True,
+        )
+
+        rendered = self._render_booking_agreement_markdown(enquiry)
+        pdf_bytes = generate_booking_agreement_pdf(enquiry)
+
+        self.assertTrue(pdf_bytes.startswith(b"%PDF"))
+        self.assertIn("**Agency / business name:** ______________________________", rendered)
+        self.assertIn("**Registered / business address:** ______________________________", rendered)
+        self.assertIn("**Listing type:** ______________________________", rendered)
+        self.assertIn("**Shoot time:** ______________________________", rendered)
+        self.assertIn("**Access contact on site:** ______________________________", rendered)
+        self.assertIn("**Access notes / restrictions:** ______________________________", rendered)
+        self.assertIn("**Travel details:** ______________________________", rendered)
+        self.assertIn("**VAT:** ______________________________", rendered)
+        self.assertIn("**Total fee including VAT:** ______________________________", rendered)
+        self.assertIn("**Deposit required:** ______________________________", rendered)
+        self.assertIn("**Balance due on delivery:** ______________________________", rendered)
+        self.assertNotIn("To be confirmed", rendered)
+        self.assertNotIn("To be confirmed by the Client", rendered)
+
+    def test_booking_agreement_quote_amounts_and_signatures_render(self):
+        enquiry = RealEstateEnquiry.objects.create(
+            name="Jane Agent",
+            email="jane@example.com",
+            phone="+353 87 123 4567",
+            company_name="Example Estate Agents",
+            client_type=RealEstateEnquiry.ClientType.ESTATE_AGENT,
+            property_address="Example House, Salthill",
+            county="Galway",
+            property_type="Detached house",
+            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            preferred_date="2026-06-20",
+            quoted_price="399.00",
+            consent_to_contact=True,
+        )
+
+        rendered = self._render_booking_agreement_markdown(enquiry)
+
+        self.assertIn("**Package fee excluding VAT:** EUR 399.00", rendered)
+        self.assertIn("**VAT:** EUR 91.77", rendered)
+        self.assertIn("**Total fee including VAT:** EUR 490.77", rendered)
+        self.assertIn("**Deposit required:** EUR 147.23", rendered)
+        self.assertIn("**Balance due on delivery:** EUR 343.54", rendered)
+        self.assertIn("Signed electronically for and on behalf of OpenEire Studios", rendered)
+        self.assertIn("Name: Gerard Deely", rendered)
+        self.assertIn("Title: OpenEire Studios", rendered)
+        self.assertIn("Signed by or on behalf of the Client:", rendered)
+        self.assertIn("Name: ______________________________", rendered)
+        self.assertIn("Title: ______________________________", rendered)
+        self.assertIn("Date: ______________________________", rendered)
+        self.assertIn(
+            "By signing electronically and by paying the booking deposit after receipt of this Booking Agreement, the Client confirms",
+            rendered,
+        )
+        self.assertIn(
+            "private property owner, the Client may permit one appointed estate agent/auctioneer acting on their behalf",
+            rendered,
         )
 
 
@@ -713,6 +792,121 @@ class RealEstateEnquiryAdminActionTests(TestCase):
         self.model_admin.message_user.assert_any_call(
             request,
             "Confirmation email failed for 1 enquiry(s).",
+            level=messages.ERROR,
+        )
+
+    @patch("realestate.admin.send_templated_email")
+    @patch("realestate.payments.stripe.checkout.Session.create")
+    def test_deposit_request_skips_without_booking_agreement_received(
+        self,
+        mock_session_create,
+        mock_send_templated_email,
+    ):
+        request = self._request()
+
+        self.model_admin.send_deposit_request_email(
+            request,
+            RealEstateEnquiry.objects.filter(pk=self.enquiry.pk),
+        )
+
+        mock_session_create.assert_not_called()
+        mock_send_templated_email.assert_not_called()
+        self.model_admin.message_user.assert_any_call(
+            request,
+            "Skipped 1 enquiry(s) because required data was missing.",
+            level=messages.WARNING,
+        )
+
+    @patch("realestate.admin.send_templated_email")
+    @patch("realestate.payments.stripe.checkout.Session.create")
+    def test_deposit_request_creates_stripe_checkout_when_link_missing(
+        self,
+        mock_session_create,
+        mock_send_templated_email,
+    ):
+        request = self._request()
+        self.enquiry.booking_agreement_received = True
+        self.enquiry.save(update_fields=["booking_agreement_received"])
+        mock_session_create.return_value = {
+            "id": "cs_realestate_deposit",
+            "url": "https://checkout.stripe.com/c/pay/realestate",
+        }
+
+        self.model_admin.send_deposit_request_email(
+            request,
+            RealEstateEnquiry.objects.filter(pk=self.enquiry.pk),
+        )
+
+        self.enquiry.refresh_from_db()
+        self.assertEqual(
+            self.enquiry.deposit_payment_link,
+            "https://checkout.stripe.com/c/pay/realestate",
+        )
+        self.assertEqual(self.enquiry.stripe_deposit_session_id, "cs_realestate_deposit")
+        mock_session_create.assert_called_once()
+        call_kwargs = mock_session_create.call_args.kwargs
+        self.assertEqual(call_kwargs["mode"], "payment")
+        self.assertEqual(call_kwargs["line_items"][0]["price_data"]["unit_amount"], 14723)
+        self.assertEqual(call_kwargs["metadata"]["realestate_enquiry_id"], str(self.enquiry.pk))
+        self.assertEqual(call_kwargs["metadata"]["purpose"], "realestate_deposit")
+        mock_send_templated_email.assert_called_once()
+        email_context = mock_send_templated_email.call_args.kwargs["context"]
+        self.assertEqual(
+            email_context["deposit_payment_link"],
+            "https://checkout.stripe.com/c/pay/realestate",
+        )
+        self.assertIn("147.23", email_context["deposit_amount"])
+        self.assertIn("343.54", email_context["balance_due"])
+
+    @patch("realestate.admin.send_templated_email")
+    @patch("realestate.payments.stripe.checkout.Session.create")
+    def test_deposit_request_reuses_existing_link(
+        self,
+        mock_session_create,
+        mock_send_templated_email,
+    ):
+        request = self._request()
+        self.enquiry.booking_agreement_received = True
+        self.enquiry.deposit_payment_link = "https://checkout.stripe.com/existing"
+        self.enquiry.save(
+            update_fields=["booking_agreement_received", "deposit_payment_link"]
+        )
+
+        self.model_admin.send_deposit_request_email(
+            request,
+            RealEstateEnquiry.objects.filter(pk=self.enquiry.pk),
+        )
+
+        mock_session_create.assert_not_called()
+        mock_send_templated_email.assert_called_once()
+        self.assertEqual(
+            mock_send_templated_email.call_args.kwargs["context"]["deposit_payment_link"],
+            "https://checkout.stripe.com/existing",
+        )
+
+    @patch("realestate.admin.send_templated_email")
+    @patch("realestate.payments.stripe.checkout.Session.create")
+    def test_deposit_request_stripe_failure_does_not_send_email(
+        self,
+        mock_session_create,
+        mock_send_templated_email,
+    ):
+        request = self._request()
+        self.enquiry.booking_agreement_received = True
+        self.enquiry.save(update_fields=["booking_agreement_received"])
+        mock_session_create.side_effect = RuntimeError("stripe timeout")
+
+        self.model_admin.send_deposit_request_email(
+            request,
+            RealEstateEnquiry.objects.filter(pk=self.enquiry.pk),
+        )
+
+        self.enquiry.refresh_from_db()
+        self.assertEqual(self.enquiry.deposit_payment_link, "")
+        mock_send_templated_email.assert_not_called()
+        self.model_admin.message_user.assert_any_call(
+            request,
+            "Deposit request email failed for 1 enquiry(s).",
             level=messages.ERROR,
         )
 


### PR DESCRIPTION
## Summary

Automates the real estate booking deposit flow by creating a Stripe Checkout Session from the admin deposit request action, storing the generated payment link/session reference, and marking deposits paid from validated Stripe webhooks. Also replaces the generic booking agreement with the canonical OpenEire agreement and renders missing agreement fields as fill-in blanks.

## Why

Petra/Gerry should not need to manually create and paste `deposit_payment_link` before sending the Deposit Request email. This supports the real estate booking flow: Quote -> Booking Agreement -> signed agreement received -> Deposit Request -> Stripe payment -> Confirmation.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Added `realestate/payments.py` for real estate quote/VAT/deposit/balance calculations and Stripe Checkout Session creation.
  - Updated the Real Estate admin deposit action to require signed agreement + quote, create/reuse a Stripe checkout URL, and only send the email after a link is available.
  - Added real estate deposit payment state fields and migration: `stripe_deposit_session_id`, `deposit_paid`, `deposit_paid_at`, plus widened `deposit_payment_link`.
  - Extended Stripe `checkout.session.completed` webhook handling for `purpose=realestate_deposit`, with session id, amount, and currency validation before marking an enquiry booked.
  - Replaced the generic booking agreement Markdown with the canonical OpenEire agreement.
  - Updated booking agreement generation so missing optional fields render as visible blank fill-in lines.
  - Added tests for deposit admin behaviour, Stripe webhook handling/failure cases, and booking agreement rendering.

- Frontend:
  - None.

- Infra/Config:
  - Added Django migration for real estate deposit payment tracking fields.
  - No new environment variables.

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

Manual smoke tested:
- Generated Booking Agreement PDFs from minimal and quoted enquiries.
- Verified missing agreement fields render as blanks, not "To be confirmed".
- Verified quoted agreement renders quote/VAT/deposit/balance values.
- Verified webhook tests cover valid deposit payment, amount mismatch, session mismatch, and missing metadata.

Commands run:
- `py manage.py test realestate.tests`
- `py manage.py test checkout.tests.StripeWebhookLicenseTests`
- `$env:FULFILMENT_ALERT_RECIPIENTS='ops@example.com'; py manage.py check`
- `$env:FULFILMENT_ALERT_RECIPIENTS='ops@example.com'; py manage.py makemigrations realestate --check --dry-run`

Note: full `makemigrations --check --dry-run` reports an unrelated pending migration inside installed `django_summernote`; the `realestate` app check reports no changes detected.

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described:

Hotfix path:
- If Stripe deposit creation has issues, revert the admin action/helper/webhook changes and temporarily return to manually populated `deposit_payment_link`.
- If webhook marking is too strict in production, adjust validation to reconcile via Stripe Dashboard event/session details before retrying the failed webhook.
- Booking Agreement Markdown can be reverted independently if legal wording/layout needs urgent correction.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Please focus especially on:
- Live Stripe safety: deposit amount/currency/session id validation before marking `deposit_paid`.
- Whether failed real estate deposit webhooks should retry as implemented.
- Booking Agreement legal wording and placeholder behaviour.
- Ensuring product/photo checkout and licence webhook behaviour remains unchanged.