### PR TITLE
Add real estate delivery provider metadata

### DIFF
--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -15,6 +15,25 @@ from .payments import create_realestate_deposit_checkout_session
 
 @admin.register(RealEstateEnquiry, site=custom_admin_site)
 class RealEstateEnquiryAdmin(admin.ModelAdmin):
+    booking_field_help_texts = {
+        "booking_agreement_link": (
+            "Optional future e-signature/external signing URL. The Booking "
+            "Agreement PDF is attached automatically when sending the Booking "
+            "Agreement email."
+        ),
+        "delivery_provider": (
+            "Where the finished media package is hosted. Until the OpenEire "
+            "Client Portal is available, MyAirBridge is the recommended provider."
+        ),
+        "delivery_link": (
+            'Secure download URL used for the "Download Files" button in the '
+            "Delivery email."
+        ),
+        "review_link": (
+            "Review URL shown as the Follow-up/Thank-you email CTA, usually "
+            "the Google review link."
+        ),
+    }
     list_display = (
         "created_at",
         "name",
@@ -112,14 +131,15 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
             {
                 "fields": (
                     "proposed_shoot_date",
-                    "booking_agreement_link",
                     "booking_agreement_received",
                     "deposit_payment_link",
                     "stripe_deposit_session_id",
                     "deposit_paid",
                     "deposit_paid_at",
+                    "delivery_provider",
                     "delivery_link",
                     "review_link",
+                    "booking_agreement_link",
                 )
             },
         ),
@@ -146,6 +166,12 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
     def _get_reply_to(self):
         reply_to_email = get_realestate_reply_to_email()
         return [reply_to_email] if reply_to_email else []
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
+        if formfield and db_field.name in self.booking_field_help_texts:
+            formfield.help_text = self.booking_field_help_texts[db_field.name]
+        return formfield
 
     def _build_base_context(self, enquiry):
         confirmed_or_preferred_date = enquiry.shoot_date or enquiry.preferred_date
@@ -384,7 +410,10 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
             template_base="delivery",
             description="Delivery email",
             warning_messages=lambda enquiry, context: [
-                "delivery CTA omitted because no delivery link is stored."
+                (
+                    "Delivery email sent, but no delivery CTA was included "
+                    "because no delivery link is stored."
+                )
                 if not context.get("delivery_link")
                 else ""
             ],
@@ -399,7 +428,7 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
             template_base="follow_up",
             description="Follow-up email",
             warning_messages=lambda enquiry, context: [
-                "review CTA omitted because no review link is stored."
+                "Review CTA omitted because no review link is stored."
                 if not context.get("review_link")
                 else ""
             ],
@@ -434,7 +463,7 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
             template_base="thank_you",
             description="Thank-you email",
             warning_messages=lambda enquiry, context: [
-                "review CTA omitted because no review link is stored."
+                "Review CTA omitted because no review link is stored."
                 if not context.get("review_link")
                 else ""
             ],

--- a/realestate/migrations/0005_realestateenquiry_delivery_provider.py
+++ b/realestate/migrations/0005_realestateenquiry_delivery_provider.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("realestate", "0004_realestateenquiry_deposit_payment_state"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="delivery_provider",
+            field=models.CharField(
+                choices=[
+                    ("myairbridge", "MyAirBridge"),
+                    ("google_drive", "Google Drive"),
+                    ("dropbox", "Dropbox"),
+                    ("onedrive", "OneDrive"),
+                    ("portal", "OpenEire Client Portal"),
+                    ("other", "Other"),
+                ],
+                default="myairbridge",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/realestate/models.py
+++ b/realestate/models.py
@@ -37,6 +37,14 @@ class RealEstateEnquiry(models.Model):
         CLOSED = "closed", "Closed"
         SPAM = "spam", "Spam"
 
+    class DeliveryProvider(models.TextChoices):
+        MYAIRBRIDGE = "myairbridge", "MyAirBridge"
+        GOOGLE_DRIVE = "google_drive", "Google Drive"
+        DROPBOX = "dropbox", "Dropbox"
+        ONEDRIVE = "onedrive", "OneDrive"
+        PORTAL = "portal", "OpenEire Client Portal"
+        OTHER = "other", "Other"
+
     ADD_ON_LABELS = {
         "additional_stills": "Additional edited stills - EUR 10+VAT per image",
         "floor_plan": "Floor plan, 2D measured - EUR 75+VAT",
@@ -47,11 +55,11 @@ class RealEstateEnquiry(models.Model):
     }
 
     PACKAGE_SUMMARIES = {
-        PreferredPackage.ESSENTIAL: "EUR 175+VAT - 10 edited interior/exterior photos",
-        PreferredPackage.STARTER: "EUR 229+VAT - 20 edited interior/exterior photos + 5-8 aerial drone photos",
-        PreferredPackage.PRO: "EUR 399+VAT - 25 edited interior/exterior photos + 5-8 aerial drone photos + 60-90s 4K aerial drone video + social media cuts",
-        PreferredPackage.PREMIUM: "EUR 579+VAT - 30 edited interior/exterior photos + 5-8 aerial drone photos + aerial video + social media cuts + 3D interactive virtual tour",
-        PreferredPackage.CUSTOM: "POA",
+        PreferredPackage.ESSENTIAL: "Essential - EUR 175+VAT - 10 edited interior/exterior photos",
+        PreferredPackage.STARTER: "Starter - EUR 229+VAT - 20 edited interior/exterior photos + 5-8 aerial drone photos",
+        PreferredPackage.PRO: "Pro - EUR 399+VAT - 25 edited interior/exterior photos + 5-8 aerial drone photos + 60-90s 4K aerial drone video + social media cuts",
+        PreferredPackage.PREMIUM: "Premium - EUR 579+VAT - 30 edited interior/exterior photos + 5-8 aerial drone photos + aerial video + social media cuts + 3D interactive virtual tour",
+        PreferredPackage.CUSTOM: "Custom - POA",
         PreferredPackage.NOT_SURE: "Not sure yet",
     }
 
@@ -86,6 +94,14 @@ class RealEstateEnquiry(models.Model):
     deposit_paid = models.BooleanField(default=False)
     deposit_paid_at = models.DateTimeField(null=True, blank=True)
     booking_agreement_link = models.URLField(blank=True)
+    # Delivery provider is metadata only. When the Client Portal ships, use
+    # provider="portal" and delivery_link="https://app.openeire.ie/projects/<token>";
+    # the Delivery email can keep using the same delivery_link CTA.
+    delivery_provider = models.CharField(
+        max_length=20,
+        choices=DeliveryProvider.choices,
+        default=DeliveryProvider.MYAIRBRIDGE,
+    )
     delivery_link = models.URLField(blank=True)
     review_link = models.URLField(blank=True)
 

--- a/realestate/tests.py
+++ b/realestate/tests.py
@@ -296,6 +296,36 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
         self.assertIn("Download Media", html)
         self.assertIn("https://openeire.ie/delivery/example", html)
 
+    def test_delivery_cta_depends_on_link_not_provider(self):
+        for provider in RealEstateEnquiry.DeliveryProvider.values:
+            with self.subTest(provider=provider):
+                context = {
+                    **REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
+                    "delivery_provider": provider,
+                    "delivery_link": f"https://example.com/{provider}/delivery",
+                }
+
+                html = render_to_string("emails/real_estate/delivery.html", context)
+                text = render_to_string("emails/real_estate/delivery.txt", context)
+
+                self.assertIn("Download Media", html)
+                self.assertIn(context["delivery_link"], html)
+                self.assertIn(context["delivery_link"], text)
+
+    def test_delivery_cta_is_omitted_without_delivery_link(self):
+        context = {
+            **REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
+            "delivery_provider": RealEstateEnquiry.DeliveryProvider.PORTAL,
+            "delivery_link": "",
+        }
+
+        html = render_to_string("emails/real_estate/delivery.html", context)
+        text = render_to_string("emails/real_estate/delivery.txt", context)
+
+        self.assertNotIn("Download Media", html)
+        self.assertNotIn("href=\"\"", html)
+        self.assertNotIn("Download Media:", text)
+
     def test_follow_up_cta_appears_with_review_link(self):
         html = render_to_string(
             "emails/real_estate/follow_up.html",
@@ -543,6 +573,10 @@ class RealEstateEnquiryTests(APITestCase):
         self.assertEqual(response.data["status"], "new")
         self.assertEqual(response.data["message"], "Enquiry received successfully.")
         self.assertNotIn("internal_notes", response.data)
+        self.assertEqual(
+            enquiry.delivery_provider,
+            RealEstateEnquiry.DeliveryProvider.MYAIRBRIDGE,
+        )
 
     def test_internal_notification_email_is_sent(self):
         self.client.post(self.url, data=self.payload, format="json")
@@ -692,6 +726,54 @@ class RealEstateEnquiryAdminActionTests(TestCase):
         request.user = self.user
         return request
 
+    def test_booking_delivery_admin_fields_are_ordered_and_helpful(self):
+        request = self._request()
+        booking_fieldset = next(
+            fieldset
+            for fieldset in self.model_admin.fieldsets
+            if fieldset[0] == "Booking & Delivery Links"
+        )
+
+        self.assertEqual(
+            booking_fieldset[1]["fields"],
+            (
+                "proposed_shoot_date",
+                "booking_agreement_received",
+                "deposit_payment_link",
+                "stripe_deposit_session_id",
+                "deposit_paid",
+                "deposit_paid_at",
+                "delivery_provider",
+                "delivery_link",
+                "review_link",
+                "booking_agreement_link",
+            ),
+        )
+        self.assertIn("booking_agreement_received", self.model_admin.list_display)
+        self.assertIn("deposit_paid", self.model_admin.list_display)
+        self.assertNotIn("delivery_provider", self.model_admin.list_display)
+        self.assertIn("stripe_deposit_session_id", self.model_admin.readonly_fields)
+        self.assertIn("deposit_paid_at", self.model_admin.readonly_fields)
+        self.assertNotIn("deposit_payment_link", self.model_admin.readonly_fields)
+
+        form = self.model_admin.get_form(request)
+        self.assertIn(
+            "Booking Agreement PDF is attached automatically",
+            form.base_fields["booking_agreement_link"].help_text,
+        )
+        self.assertIn(
+            "Where the finished media package is hosted",
+            form.base_fields["delivery_provider"].help_text,
+        )
+        self.assertIn(
+            'Secure download URL used for the "Download Files" button',
+            form.base_fields["delivery_link"].help_text,
+        )
+        self.assertIn(
+            "Review URL shown as the Follow-up/Thank-you email CTA",
+            form.base_fields["review_link"].help_text,
+        )
+
     @patch("realestate.admin.send_templated_email")
     def test_send_quote_email_uses_existing_context(self, mock_send_templated_email):
         request = self._request()
@@ -729,7 +811,72 @@ class RealEstateEnquiryAdminActionTests(TestCase):
             if call.kwargs.get("level") == messages.WARNING
         ]
         self.assertTrue(
-            any("delivery CTA omitted" in call.args[1] for call in warning_calls)
+            any(
+                "Delivery email sent, but no delivery CTA was included because no delivery link is stored."
+                in call.args[1]
+                for call in warning_calls
+            )
+        )
+        self.model_admin.message_user.assert_any_call(
+            request,
+            "Delivery email sent for 1 enquiry(s).",
+            level=messages.SUCCESS,
+        )
+
+    @patch("realestate.admin.send_templated_email")
+    def test_follow_up_email_warns_when_review_link_missing(self, mock_send_templated_email):
+        request = self._request()
+
+        self.model_admin.send_follow_up_email(
+            request,
+            RealEstateEnquiry.objects.filter(pk=self.enquiry.pk),
+        )
+
+        mock_send_templated_email.assert_called_once()
+        warning_calls = [
+            call
+            for call in self.model_admin.message_user.call_args_list
+            if call.kwargs.get("level") == messages.WARNING
+        ]
+        self.assertTrue(
+            any(
+                "Review CTA omitted because no review link is stored."
+                in call.args[1]
+                for call in warning_calls
+            )
+        )
+        self.model_admin.message_user.assert_any_call(
+            request,
+            "Follow-up email sent for 1 enquiry(s).",
+            level=messages.SUCCESS,
+        )
+
+    @patch("realestate.admin.send_templated_email")
+    def test_thank_you_email_warns_when_review_link_missing(self, mock_send_templated_email):
+        request = self._request()
+
+        self.model_admin.send_thank_you_email(
+            request,
+            RealEstateEnquiry.objects.filter(pk=self.enquiry.pk),
+        )
+
+        mock_send_templated_email.assert_called_once()
+        warning_calls = [
+            call
+            for call in self.model_admin.message_user.call_args_list
+            if call.kwargs.get("level") == messages.WARNING
+        ]
+        self.assertTrue(
+            any(
+                "Review CTA omitted because no review link is stored."
+                in call.args[1]
+                for call in warning_calls
+            )
+        )
+        self.model_admin.message_user.assert_any_call(
+            request,
+            "Thank-you email sent for 1 enquiry(s).",
+            level=messages.SUCCESS,
         )
 
     @patch("realestate.admin.send_templated_email")
@@ -759,6 +906,12 @@ class RealEstateEnquiryAdminActionTests(TestCase):
             "Booking agreement email sent for 1 enquiry(s).",
             level=messages.SUCCESS,
         )
+        warning_calls = [
+            call
+            for call in self.model_admin.message_user.call_args_list
+            if call.kwargs.get("level") == messages.WARNING
+        ]
+        self.assertEqual(warning_calls, [])
 
     @patch("realestate.admin.send_templated_email")
     def test_weather_reschedule_skips_without_revised_date(self, mock_send_templated_email):


### PR DESCRIPTION
## Summary

Adds a delivery provider abstraction for real estate enquiries while keeping the existing Delivery email behaviour unchanged. Also clarifies the Real Estate admin workflow around Booking Agreement, delivery, and review links.

## Why

Until the OpenEire Client Portal is built, real estate deliveries will usually use MyAirBridge. This gives admins a clear provider field now while preserving the existing client-facing `delivery_link` workflow.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Added `delivery_provider` to `RealEstateEnquiry`, defaulting to `myairbridge`.
  - Added provider choices: MyAirBridge, Google Drive, Dropbox, OneDrive, OpenEire Client Portal, Other.
  - Added admin help text for delivery provider, delivery link, review link, and booking agreement link.
  - Added `delivery_provider` above `delivery_link` in the Booking & Delivery admin section.
  - Kept `delivery_provider` out of `list_display` to avoid widening the changelist.
  - Confirmed Delivery email CTA still depends only on `delivery_link`, not provider.
  - Kept Booking Agreement link optional and documented as future e-signature/external signing metadata.

- Frontend:
  - None.

- Infra/Config:
  - Added migration `0005_realestateenquiry_delivery_provider`.

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

Commands run:
- `py manage.py test realestate.tests`
- `py manage.py test checkout.tests.StripeWebhookLicenseTests`
- `$env:FULFILMENT_ALERT_RECIPIENTS='ops@example.com'; py manage.py check`
- `$env:FULFILMENT_ALERT_RECIPIENTS='ops@example.com'; py manage.py makemigrations realestate --check --dry-run`

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described:

Hotfix path:
- Revert the migration/model/admin changes if the provider field causes admin or migration issues.
- Delivery email behaviour can continue using `delivery_link` alone; no template rollback should be needed because templates were not changed.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [ ] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Please focus especially on:
- Whether the provider choices are sufficient for current delivery operations.
- Confirming `delivery_provider` remains metadata-only.
- Confirming Delivery email CTA behaviour is unchanged.
- Admin field ordering/help text clarity.