### PR TITLE
Fix real-estate VAT handling and preserve historical pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ Stripe:
 - `STRIPE_PUBLIC_KEY`
 - `STRIPE_SECRET_KEY`
 - `STRIPE_WEBHOOK_SECRET`
+- `VAT_REGISTERED` (defaults to `False`)
+- `VAT_RATE` (defaults to `0.23`)
+- `REALESTATE_PRICE_INPUT_IS_GROSS` (defaults to `True`; advertised and manually entered real-estate prices are final totals)
 - `STRIPE_TIMEOUT_SECONDS`
 - `STRIPE_MAX_NETWORK_RETRIES`
 - `STRIPE_WEBHOOK_STALE_PROCESSING_SECONDS`

--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -965,7 +965,7 @@ class StripeWebhookLicenseTests(TestCase):
                     "id": "cs_realestate_deposit",
                     "payment_status": "paid",
                     "payment_intent": "pi_realestate_deposit",
-                    "amount_total": 14723,
+                    "amount_total": 11970,
                     "currency": "eur",
                     "metadata": {
                         "purpose": "realestate_deposit",
@@ -1030,7 +1030,7 @@ class StripeWebhookLicenseTests(TestCase):
             "id": "cs_realestate_deposit",
             "payment_status": "paid",
             "payment_intent": "pi_realestate_deposit",
-            "amount_total": 14723,
+            "amount_total": 11970,
             "currency": "eur",
             "metadata": {
                 "purpose": "realestate_deposit",

--- a/docs/real_estate_email_qa.md
+++ b/docs/real_estate_email_qa.md
@@ -37,7 +37,8 @@ Use this checklist before enabling or changing any real estate email flow in pro
 - [ ] Quote emails clearly state the booking is confirmed only after both the Booking Agreement is signed and the booking deposit has cleared.
 - [ ] Quote emails include a "Proceed with this quote" mailto button when a reply email is configured.
 - [ ] Quote emails show a safe highlighted fallback message instead of a broken button when no reply email is configured.
-- [ ] Quote price summary displays only supplied rows: quote total ex VAT, VAT, total incl. VAT, deposit required, and balance on delivery.
+- [ ] New quote price summary displays package total, zero VAT, total payable, deposit required, balance on delivery, and the supplier-not-VAT-registered notice.
+- [ ] Historical quote price summaries retain their snapshotted VAT treatment and monetary values.
 - [ ] Quote price summary never shows `€None`, `€.00`, or blank rows.
 - [ ] Quote plain-text emails mirror the HTML quote summary and booking-confirmation conditions.
 - [ ] Booking/deposit emails use "Pay Secure Deposit" as the primary CTA when a deposit link is present.

--- a/openeire_api/settings.py
+++ b/openeire_api/settings.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from decimal import Decimal
 from pathlib import Path
 import sys
 from urllib.parse import urlsplit
@@ -616,6 +617,16 @@ def _stripe_payment_method_types_from_env(raw_value):
 
 STRIPE_PAYMENT_METHOD_TYPES = _stripe_payment_method_types_from_env(
     os.getenv("STRIPE_PAYMENT_METHOD_TYPES", "card")
+)
+
+# Real-estate prices are advertised and entered as final customer totals. Keep
+# the VAT capability configurable so registration can be enabled later without
+# changing historical quote snapshots.
+VAT_REGISTERED = env_bool(os.getenv("VAT_REGISTERED"), default=False)
+VAT_RATE = Decimal(os.getenv("VAT_RATE", "0.23"))
+REALESTATE_PRICE_INPUT_IS_GROSS = env_bool(
+    os.getenv("REALESTATE_PRICE_INPUT_IS_GROSS"),
+    default=True,
 )
 CHECKOUT_TERMS_VERSION = os.getenv("CHECKOUT_TERMS_VERSION", "2026-06-23")
 CHECKOUT_PRIVACY_VERSION = os.getenv("CHECKOUT_PRIVACY_VERSION", "2026-06-23")

--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -135,6 +135,15 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
         "updated_at",
         "stripe_deposit_session_id",
         "deposit_paid_at",
+        "pricing_snapshot_version",
+        "price_input_is_gross",
+        "vat_registered_at_quote",
+        "quoted_vat_rate",
+        "quoted_subtotal",
+        "quoted_vat_amount",
+        "quoted_total",
+        "quoted_deposit_amount",
+        "quoted_balance_due",
     )
     actions = (
         "send_quote_email",
@@ -209,6 +218,27 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
                     "review_link",
                     "booking_agreement_link",
                 )
+            },
+        ),
+        (
+            "Pricing snapshot",
+            {
+                "fields": (
+                    "pricing_snapshot_version",
+                    "price_input_is_gross",
+                    "vat_registered_at_quote",
+                    "quoted_vat_rate",
+                    "quoted_subtotal",
+                    "quoted_vat_amount",
+                    "quoted_total",
+                    "quoted_deposit_amount",
+                    "quoted_balance_due",
+                ),
+                "description": (
+                    "Immutable monetary values used for quote documents, deposits, "
+                    "balances, and Stripe validation. Existing quotes retain their "
+                    "original VAT treatment."
+                ),
             },
         ),
         (

--- a/realestate/docs/booking_agreement.md
+++ b/realestate/docs/booking_agreement.md
@@ -48,9 +48,14 @@ and
 The Client books the following package:
 
 **Package name:** {{ package_name }}  
-**Package fee excluding VAT:** {{ quote_total }}  
+**{% if vat_registered and not price_input_is_gross %}Package fee excluding VAT{% else %}Package total{% endif %}:** {{ quote_total }}
+
 **VAT:** {{ vat_total }}  
-**Total fee including VAT:** {{ total_including_vat }}  
+**Total fee payable:** {{ total_including_vat }}
+
+{% if not vat_registered %}*{{ vat_notice }}*
+
+{% endif %}
 **Deposit required:** {{ deposit_amount }}  
 **Balance due on delivery:** {{ balance_due }}
 

--- a/realestate/documents.py
+++ b/realestate/documents.py
@@ -138,6 +138,9 @@ def _build_booking_agreement_context(enquiry):
         ),
         "deposit_amount": _format_agreement_money(quote_amounts.get("deposit_amount")),
         "balance_due": _format_agreement_money(quote_amounts.get("balance_due")),
+        "vat_registered": quote_amounts.get("vat_registered", False),
+        "price_input_is_gross": quote_amounts.get("price_input_is_gross", True),
+        "vat_notice": "VAT not applicable — supplier not VAT registered",
     }
 
 

--- a/realestate/emails.py
+++ b/realestate/emails.py
@@ -77,6 +77,8 @@ def format_money(value):
         if not cleaned_value or cleaned_value.lower() in {"none", "null"}:
             return ""
         numeric_value = cleaned_value.replace("€", "").replace(",", "").strip()
+        if numeric_value.upper().startswith("EUR "):
+            numeric_value = numeric_value[4:].strip()
     else:
         numeric_value = str(value).strip()
 
@@ -194,6 +196,10 @@ def build_realestate_email_context(enquiry, **overrides):
         "total_including_vat": "",
         "deposit_amount": "",
         "balance_due": "",
+        "vat_registered": False,
+        "vat_rate_percent": Decimal("0.00"),
+        "price_input_is_gross": True,
+        "vat_notice": "VAT not applicable — supplier not VAT registered",
         "shoot_date": _format_date(getattr(enquiry, "shoot_date", None)),
         "shoot_time": "",
         "booking_reference": (

--- a/realestate/migrations/0007_realestate_pricing_snapshots.py
+++ b/realestate/migrations/0007_realestate_pricing_snapshots.py
@@ -1,0 +1,98 @@
+from decimal import Decimal, ROUND_HALF_UP
+
+from django.db import migrations, models
+
+
+MONEY = Decimal("0.01")
+LEGACY_VAT_RATE = Decimal("0.23")
+DEPOSIT_RATE = Decimal("0.30")
+
+
+def money(value):
+    return Decimal(value).quantize(MONEY, rounding=ROUND_HALF_UP)
+
+
+def backfill_legacy_pricing_snapshots(apps, schema_editor):
+    RealEstateEnquiry = apps.get_model("realestate", "RealEstateEnquiry")
+    for enquiry in RealEstateEnquiry.objects.exclude(quoted_price__isnull=True).iterator():
+        quote_total = money(enquiry.quoted_price)
+        vat_amount = money(quote_total * LEGACY_VAT_RATE)
+        final_total = money(quote_total + vat_amount)
+        deposit_amount = money(final_total * DEPOSIT_RATE)
+        balance_due = money(final_total - deposit_amount)
+
+        enquiry.pricing_snapshot_version = 1
+        enquiry.price_input_is_gross = False
+        enquiry.vat_registered_at_quote = True
+        enquiry.quoted_vat_rate = LEGACY_VAT_RATE
+        enquiry.quoted_subtotal = quote_total
+        enquiry.quoted_vat_amount = vat_amount
+        enquiry.quoted_total = final_total
+        enquiry.quoted_deposit_amount = deposit_amount
+        enquiry.quoted_balance_due = balance_due
+        enquiry.save(
+            update_fields=[
+                "pricing_snapshot_version",
+                "price_input_is_gross",
+                "vat_registered_at_quote",
+                "quoted_vat_rate",
+                "quoted_subtotal",
+                "quoted_vat_amount",
+                "quoted_total",
+                "quoted_deposit_amount",
+                "quoted_balance_due",
+            ]
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [("realestate", "0006_realestatetimelineevent")]
+
+    operations = [
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="pricing_snapshot_version",
+            field=models.PositiveSmallIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="price_input_is_gross",
+            field=models.BooleanField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="vat_registered_at_quote",
+            field=models.BooleanField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="quoted_vat_rate",
+            field=models.DecimalField(blank=True, decimal_places=5, max_digits=6, null=True),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="quoted_subtotal",
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="quoted_vat_amount",
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="quoted_total",
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="quoted_deposit_amount",
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True),
+        ),
+        migrations.AddField(
+            model_name="realestateenquiry",
+            name="quoted_balance_due",
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True),
+        ),
+        migrations.RunPython(backfill_legacy_pricing_snapshots, migrations.RunPython.noop),
+    ]

--- a/realestate/models.py
+++ b/realestate/models.py
@@ -47,19 +47,19 @@ class RealEstateEnquiry(models.Model):
         OTHER = "other", "Other"
 
     ADD_ON_LABELS = {
-        "additional_stills": "Additional edited stills - EUR 10+VAT per image",
-        "floor_plan": "Floor plan, 2D measured - EUR 75+VAT",
-        "rush_delivery": "Rush same-day delivery, stills only - EUR 75+VAT",
-        "extended_drone_video": "Extended drone video, up to 3 minutes - EUR 150+VAT",
-        "additional_social_cuts": "Additional social media cuts - EUR 50+VAT",
-        "travel_supplement": "Travel supplement beyond 40 km - EUR 0.50+VAT per km",
+        "additional_stills": "Additional edited stills - EUR 10 per image",
+        "floor_plan": "Floor plan, 2D measured - EUR 75",
+        "rush_delivery": "Rush same-day delivery, stills only - EUR 75",
+        "extended_drone_video": "Extended drone video, up to 3 minutes - EUR 150",
+        "additional_social_cuts": "Additional social media cuts - EUR 50",
+        "travel_supplement": "Travel supplement beyond 40 km - EUR 0.50 per km",
     }
 
     PACKAGE_SUMMARIES = {
-        PreferredPackage.ESSENTIAL: "Essential - EUR 175+VAT - 10 edited interior/exterior photos",
-        PreferredPackage.STARTER: "Starter - EUR 229+VAT - 20 edited interior/exterior photos + 5-8 aerial drone photos",
-        PreferredPackage.PRO: "Pro - EUR 399+VAT - 25 edited interior/exterior photos + 5-8 aerial drone photos + 60-90s 4K aerial drone video + social media cuts",
-        PreferredPackage.PREMIUM: "Premium - EUR 579+VAT - 30 edited interior/exterior photos + 5-8 aerial drone photos + aerial video + social media cuts + 3D interactive virtual tour",
+        PreferredPackage.ESSENTIAL: "Essential - EUR 175 - 10 edited interior/exterior photos",
+        PreferredPackage.STARTER: "Starter - EUR 229 - 20 edited interior/exterior photos + 5-8 aerial drone photos",
+        PreferredPackage.PRO: "Pro - EUR 399 - 25 edited interior/exterior photos + 5-8 aerial drone photos + 60-90s 4K aerial drone video + social media cuts",
+        PreferredPackage.PREMIUM: "Premium - EUR 579 - 30 edited interior/exterior photos + 5-8 aerial drone photos + aerial video + social media cuts + 3D interactive virtual tour",
         PreferredPackage.CUSTOM: "Custom - POA",
         PreferredPackage.NOT_SURE: "Not sure yet",
     }
@@ -83,6 +83,45 @@ class RealEstateEnquiry(models.Model):
 
     status = models.CharField(max_length=20, choices=Status.choices, default=Status.NEW)
     quoted_price = models.DecimalField(max_digits=8, decimal_places=2, null=True, blank=True)
+    pricing_snapshot_version = models.PositiveSmallIntegerField(null=True, blank=True)
+    price_input_is_gross = models.BooleanField(null=True, blank=True)
+    vat_registered_at_quote = models.BooleanField(null=True, blank=True)
+    quoted_vat_rate = models.DecimalField(
+        max_digits=6,
+        decimal_places=5,
+        null=True,
+        blank=True,
+    )
+    quoted_subtotal = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+    )
+    quoted_vat_amount = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+    )
+    quoted_total = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+    )
+    quoted_deposit_amount = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+    )
+    quoted_balance_due = models.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+    )
     shoot_date = models.DateField(null=True, blank=True)
     internal_notes = models.TextField(blank=True)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/realestate/payments.py
+++ b/realestate/payments.py
@@ -11,15 +11,50 @@ from .emails import get_realestate_site_url
 
 logger = logging.getLogger(__name__)
 
-VAT_RATE = Decimal("0.23")
 DEPOSIT_RATE = Decimal("0.30")
+PRICING_SNAPSHOT_VERSION = 1
+PRICING_SNAPSHOT_FIELDS = (
+    "pricing_snapshot_version",
+    "price_input_is_gross",
+    "vat_registered_at_quote",
+    "quoted_vat_rate",
+    "quoted_subtotal",
+    "quoted_vat_amount",
+    "quoted_total",
+    "quoted_deposit_amount",
+    "quoted_balance_due",
+)
 
 
 def _money(value):
     return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
-def calculate_realestate_deposit_amounts(enquiry):
+def _snapshot_is_complete(enquiry):
+    return all(getattr(enquiry, field, None) is not None for field in PRICING_SNAPSHOT_FIELDS)
+
+
+def _amounts_from_snapshot(enquiry):
+    quote_total = (
+        enquiry.quoted_total
+        if enquiry.price_input_is_gross
+        else enquiry.quoted_subtotal
+    )
+    return {
+        "quote_total": _money(quote_total),
+        "quote_subtotal": _money(enquiry.quoted_subtotal),
+        "vat_total": _money(enquiry.quoted_vat_amount),
+        "total_including_vat": _money(enquiry.quoted_total),
+        "deposit_amount": _money(enquiry.quoted_deposit_amount),
+        "balance_due": _money(enquiry.quoted_balance_due),
+        "vat_rate": Decimal(enquiry.quoted_vat_rate),
+        "vat_rate_percent": _money(Decimal(enquiry.quoted_vat_rate) * Decimal("100")),
+        "vat_registered": bool(enquiry.vat_registered_at_quote),
+        "price_input_is_gross": bool(enquiry.price_input_is_gross),
+    }
+
+
+def calculate_realestate_deposit_amounts(enquiry, *, persist_snapshot=True):
     if getattr(enquiry, "quoted_price", None) is None:
         raise ValueError("Quoted price is required before creating a deposit checkout.")
 
@@ -27,17 +62,60 @@ def calculate_realestate_deposit_amounts(enquiry):
     if quote_total <= 0:
         raise ValueError("Quoted price must be greater than zero.")
 
-    vat_total = _money(quote_total * VAT_RATE)
-    total_including_vat = _money(quote_total + vat_total)
+    if _snapshot_is_complete(enquiry):
+        return _amounts_from_snapshot(enquiry)
+
+    vat_registered = bool(getattr(settings, "VAT_REGISTERED", False))
+    vat_rate = Decimal(str(getattr(settings, "VAT_RATE", Decimal("0.23"))))
+    price_input_is_gross = bool(
+        getattr(settings, "REALESTATE_PRICE_INPUT_IS_GROSS", True)
+    )
+
+    if not vat_registered:
+        quote_subtotal = quote_total
+        vat_total = Decimal("0.00")
+        total_including_vat = quote_total
+    elif price_input_is_gross:
+        quote_subtotal = _money(quote_total / (Decimal("1.00") + vat_rate))
+        vat_total = _money(quote_total - quote_subtotal)
+        total_including_vat = quote_total
+    else:
+        quote_subtotal = quote_total
+        vat_total = _money(quote_subtotal * vat_rate)
+        total_including_vat = _money(quote_subtotal + vat_total)
+
     deposit_amount = _money(total_including_vat * DEPOSIT_RATE)
     balance_due = _money(total_including_vat - deposit_amount)
 
+    snapshot_values = {
+        "pricing_snapshot_version": PRICING_SNAPSHOT_VERSION,
+        "price_input_is_gross": price_input_is_gross,
+        "vat_registered_at_quote": vat_registered,
+        "quoted_vat_rate": vat_rate if vat_registered else Decimal("0.00"),
+        "quoted_subtotal": quote_subtotal,
+        "quoted_vat_amount": vat_total,
+        "quoted_total": total_including_vat,
+        "quoted_deposit_amount": deposit_amount,
+        "quoted_balance_due": balance_due,
+    }
+    for field, value in snapshot_values.items():
+        setattr(enquiry, field, value)
+    if persist_snapshot and getattr(enquiry, "pk", None):
+        enquiry.save(update_fields=[*PRICING_SNAPSHOT_FIELDS, "updated_at"])
+
     return {
         "quote_total": quote_total,
+        "quote_subtotal": quote_subtotal,
         "vat_total": vat_total,
         "total_including_vat": total_including_vat,
         "deposit_amount": deposit_amount,
         "balance_due": balance_due,
+        "vat_rate": vat_rate if vat_registered else Decimal("0.00"),
+        "vat_rate_percent": _money(
+            (vat_rate if vat_registered else Decimal("0.00")) * Decimal("100")
+        ),
+        "vat_registered": vat_registered,
+        "price_input_is_gross": price_input_is_gross,
     }
 
 

--- a/realestate/tests.py
+++ b/realestate/tests.py
@@ -24,6 +24,7 @@ from .emails import format_money
 from .emails import send_templated_email
 from .models import RealEstateEnquiry
 from .models import RealEstateTimelineEvent
+from .payments import calculate_realestate_deposit_amounts
 
 
 REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT = {
@@ -34,10 +35,14 @@ REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT = {
     "package_name": "Pro package",
     "addons": ["2D measured floor plan", "Additional social media cuts"],
     "quote_total": "399",
-    "vat_total": "91.77",
-    "total_including_vat": "490.77",
-    "deposit_amount": "147.23",
-    "balance_due": "343.54",
+    "vat_total": "0.00",
+    "total_including_vat": "399.00",
+    "deposit_amount": "119.70",
+    "balance_due": "279.30",
+    "vat_registered": False,
+    "vat_rate_percent": Decimal("0.00"),
+    "price_input_is_gross": True,
+    "vat_notice": "VAT not applicable — supplier not VAT registered",
     "shoot_date": "2026-06-20",
     "shoot_time": "10:00",
     "booking_reference": "RE-123",
@@ -55,6 +60,90 @@ REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT = {
     "cta_url": "",
     "cta_label": "",
 }
+
+
+class RealEstatePricingTests(TestCase):
+    def _enquiry(self, **overrides):
+        values = {
+            "name": "Jane Agent",
+            "email": "jane@example.com",
+            "phone": "+353 87 123 4567",
+            "client_type": RealEstateEnquiry.ClientType.ESTATE_AGENT,
+            "property_address": "Example House",
+            "county": "Galway",
+            "property_type": "Detached house",
+            "preferred_package": RealEstateEnquiry.PreferredPackage.PRO,
+            "quoted_price": Decimal("399.00"),
+            "consent_to_contact": True,
+        }
+        values.update(overrides)
+        return RealEstateEnquiry.objects.create(**values)
+
+    @override_settings(
+        VAT_REGISTERED=False,
+        VAT_RATE=Decimal("0.23"),
+        REALESTATE_PRICE_INPUT_IS_GROSS=True,
+    )
+    def test_vat_disabled_treats_quote_as_final_total_and_persists_snapshot(self):
+        enquiry = self._enquiry()
+
+        amounts = calculate_realestate_deposit_amounts(enquiry)
+
+        self.assertEqual(amounts["quote_total"], Decimal("399.00"))
+        self.assertEqual(amounts["vat_total"], Decimal("0.00"))
+        self.assertEqual(amounts["total_including_vat"], Decimal("399.00"))
+        self.assertEqual(amounts["deposit_amount"], Decimal("119.70"))
+        self.assertEqual(amounts["balance_due"], Decimal("279.30"))
+        enquiry.refresh_from_db()
+        self.assertFalse(enquiry.vat_registered_at_quote)
+        self.assertTrue(enquiry.price_input_is_gross)
+        self.assertEqual(enquiry.quoted_total, Decimal("399.00"))
+
+    @override_settings(
+        VAT_REGISTERED=True,
+        VAT_RATE=Decimal("0.23"),
+        REALESTATE_PRICE_INPUT_IS_GROSS=True,
+    )
+    def test_future_vat_enabled_gross_price_extracts_vat_without_increasing_total(self):
+        amounts = calculate_realestate_deposit_amounts(self._enquiry())
+
+        self.assertEqual(amounts["quote_subtotal"], Decimal("324.39"))
+        self.assertEqual(amounts["vat_total"], Decimal("74.61"))
+        self.assertEqual(amounts["total_including_vat"], Decimal("399.00"))
+        self.assertEqual(amounts["deposit_amount"], Decimal("119.70"))
+
+    @override_settings(
+        VAT_REGISTERED=True,
+        VAT_RATE=Decimal("0.23"),
+        REALESTATE_PRICE_INPUT_IS_GROSS=False,
+    )
+    def test_future_vat_enabled_net_price_adds_configured_vat(self):
+        amounts = calculate_realestate_deposit_amounts(self._enquiry())
+
+        self.assertEqual(amounts["vat_total"], Decimal("91.77"))
+        self.assertEqual(amounts["total_including_vat"], Decimal("490.77"))
+        self.assertEqual(amounts["deposit_amount"], Decimal("147.23"))
+        self.assertEqual(amounts["balance_due"], Decimal("343.54"))
+
+    @override_settings(VAT_REGISTERED=False)
+    def test_existing_legacy_snapshot_is_not_recalculated(self):
+        enquiry = self._enquiry(
+            pricing_snapshot_version=1,
+            price_input_is_gross=False,
+            vat_registered_at_quote=True,
+            quoted_vat_rate=Decimal("0.23"),
+            quoted_subtotal=Decimal("399.00"),
+            quoted_vat_amount=Decimal("91.77"),
+            quoted_total=Decimal("490.77"),
+            quoted_deposit_amount=Decimal("147.23"),
+            quoted_balance_due=Decimal("343.54"),
+        )
+
+        amounts = calculate_realestate_deposit_amounts(enquiry)
+
+        self.assertEqual(amounts["vat_total"], Decimal("91.77"))
+        self.assertEqual(amounts["total_including_vat"], Decimal("490.77"))
+        self.assertEqual(amounts["deposit_amount"], Decimal("147.23"))
 
 
 class RealEstateEmailTemplateTests(SimpleTestCase):
@@ -207,16 +296,16 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
         self.assertEqual(format_money(None), "")
         self.assertEqual(format_money(""), "")
         self.assertEqual(format_money("null"), "")
-        self.assertEqual(format_money("EUR 399+VAT"), "")
+        self.assertEqual(format_money("EUR 399"), "€399.00")
 
     def test_quote_email_renders_logo_cta_and_price_summary(self):
         context = {
             **REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
             "quote_total": "€399.00",
-            "vat_total": "€91.77",
-            "total_including_vat": "€490.77",
-            "deposit_amount": "€147.23",
-            "balance_due": "€343.54",
+            "vat_total": "€0.00",
+            "total_including_vat": "€399.00",
+            "deposit_amount": "€119.70",
+            "balance_due": "€279.30",
         }
 
         html = render_to_string("emails/real_estate/quote.html", context)
@@ -226,19 +315,19 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
         self.assertIn("Aerial Photography", html)
         self.assertIn("Property Media", html)
         self.assertIn("Visual Licensing", html)
-        self.assertIn("Quote total (ex VAT)", html)
+        self.assertIn("Package total", html)
         self.assertIn("€399.00", html)
-        self.assertIn("VAT (23%)", html)
-        self.assertIn("€91.77", html)
-        self.assertIn("Total incl. VAT", html)
-        self.assertIn("€490.77", html)
+        self.assertIn("VAT", html)
+        self.assertIn("€0.00", html)
+        self.assertIn("Total payable", html)
         self.assertIn("Deposit required", html)
-        self.assertIn("€147.23", html)
+        self.assertIn("€119.70", html)
         self.assertIn("Balance on delivery", html)
-        self.assertIn("€343.54", html)
+        self.assertIn("€279.30", html)
+        self.assertIn("VAT not applicable", html)
         self.assertIn("Proceed with this quote", html)
         self.assertIn("mailto:shoots@openeire.ie", html)
-        self.assertIn("Quote total (ex VAT): €399.00", text)
+        self.assertIn("Package total: €399.00", text)
         self.assertIn("Proceed with this quote: shoots@openeire.ie", text)
 
     def test_quote_email_omits_blank_summary_rows_and_broken_cta(self):
@@ -489,7 +578,7 @@ class BookingAgreementDocumentTests(TestCase):
         self.assertIn("**Access notes / restrictions:** ______________________________", rendered)
         self.assertIn("**Travel details:** ______________________________", rendered)
         self.assertIn("**VAT:** ______________________________", rendered)
-        self.assertIn("**Total fee including VAT:** ______________________________", rendered)
+        self.assertIn("**Total fee payable:** ______________________________", rendered)
         self.assertIn("**Deposit required:** ______________________________", rendered)
         self.assertIn("**Balance due on delivery:** ______________________________", rendered)
         self.assertNotIn("To be confirmed", rendered)
@@ -513,11 +602,12 @@ class BookingAgreementDocumentTests(TestCase):
 
         rendered = self._render_booking_agreement_markdown(enquiry)
 
-        self.assertIn("**Package fee excluding VAT:** EUR 399.00", rendered)
-        self.assertIn("**VAT:** EUR 91.77", rendered)
-        self.assertIn("**Total fee including VAT:** EUR 490.77", rendered)
-        self.assertIn("**Deposit required:** EUR 147.23", rendered)
-        self.assertIn("**Balance due on delivery:** EUR 343.54", rendered)
+        self.assertIn("**Package total:** EUR 399.00", rendered)
+        self.assertIn("**VAT:** EUR 0.00", rendered)
+        self.assertIn("**Total fee payable:** EUR 399.00", rendered)
+        self.assertIn("**Deposit required:** EUR 119.70", rendered)
+        self.assertIn("**Balance due on delivery:** EUR 279.30", rendered)
+        self.assertIn("VAT not applicable", rendered)
         self.assertIn("Signed electronically for and on behalf of OpenEire Studios", rendered)
         self.assertIn("Name: Gerard Deely", rendered)
         self.assertIn("Title: OpenEire Studios", rendered)
@@ -601,6 +691,14 @@ class RealEstateEnquiryTests(APITestCase):
         self.assertEqual(response.data["status"], "new")
         self.assertEqual(response.data["message"], "Enquiry received successfully.")
         self.assertNotIn("internal_notes", response.data)
+        for private_pricing_field in (
+            "quoted_price",
+            "quoted_vat_amount",
+            "quoted_total",
+            "quoted_deposit_amount",
+            "quoted_balance_due",
+        ):
+            self.assertNotIn(private_pricing_field, response.data)
         self.assertEqual(
             enquiry.delivery_provider,
             RealEstateEnquiry.DeliveryProvider.MYAIRBRIDGE,
@@ -1061,7 +1159,9 @@ class RealEstateEnquiryAdminActionTests(TestCase):
         mock_session_create.assert_called_once()
         call_kwargs = mock_session_create.call_args.kwargs
         self.assertEqual(call_kwargs["mode"], "payment")
-        self.assertEqual(call_kwargs["line_items"][0]["price_data"]["unit_amount"], 14723)
+        self.assertEqual(call_kwargs["line_items"][0]["price_data"]["unit_amount"], 11970)
+        self.assertNotIn("tax_rates", call_kwargs["line_items"][0])
+        self.assertNotIn("automatic_tax", call_kwargs)
         self.assertEqual(call_kwargs["metadata"]["realestate_enquiry_id"], str(self.enquiry.pk))
         self.assertEqual(call_kwargs["metadata"]["purpose"], "realestate_deposit")
         mock_send_templated_email.assert_called_once()
@@ -1070,8 +1170,8 @@ class RealEstateEnquiryAdminActionTests(TestCase):
             email_context["deposit_payment_link"],
             "https://checkout.stripe.com/c/pay/realestate",
         )
-        self.assertIn("147.23", email_context["deposit_amount"])
-        self.assertIn("343.54", email_context["balance_due"])
+        self.assertIn("119.70", email_context["deposit_amount"])
+        self.assertIn("279.30", email_context["balance_due"])
         event = self.enquiry.timeline_events.get(
             event_type=RealEstateTimelineEvent.EventType.DEPOSIT_REQUEST_SENT
         )

--- a/templates/emails/real_estate/booking_agreement.html
+++ b/templates/emails/real_estate/booking_agreement.html
@@ -12,7 +12,8 @@
     <p style="margin:0 0 6px;"><strong>Reference:</strong> {{ booking_reference|default:"To be confirmed" }}</p>
     <p style="margin:0 0 6px;"><strong>Property:</strong> {{ property_address|default:"Not specified" }}</p>
     <p style="margin:0 0 6px;"><strong>Proposed shoot:</strong> {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}</p>
-    <p style="margin:0 0 6px;"><strong>Quote total (ex VAT):</strong> {{ quote_total|default:"To be confirmed" }}</p>
+    <p style="margin:0 0 6px;"><strong>{% if vat_registered and not price_input_is_gross %}Quote total (ex VAT){% else %}Package total{% endif %}:</strong> {{ quote_total|default:"To be confirmed" }}</p>
+    {% if not vat_registered %}<p style="margin:0 0 6px;"><strong>VAT:</strong> {{ vat_total|default:"€0.00" }}</p><p style="margin:0 0 6px;">{{ vat_notice }}</p>{% endif %}
     <p style="margin:0;"><strong>Deposit request:</strong> Sent separately once the signed agreement has been returned.</p>
   </div>
 {% endblock %}

--- a/templates/emails/real_estate/booking_agreement.txt
+++ b/templates/emails/real_estate/booking_agreement.txt
@@ -6,7 +6,10 @@ Booking details
 Reference: {{ booking_reference|default:"To be confirmed" }}
 Property: {{ property_address|default:"Not specified" }}
 Proposed shoot: {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}
-Quote total (ex VAT): {{ quote_total|default:"To be confirmed" }}
+{% if vat_registered and not price_input_is_gross %}Quote total (ex VAT){% else %}Package total{% endif %}: {{ quote_total|default:"To be confirmed" }}
+{% if not vat_registered %}VAT: {{ vat_total|default:"€0.00" }}
+{{ vat_notice }}
+{% endif %}
 Deposit request: Sent separately once the signed agreement has been returned.
 
 {% if booking_agreement_link %}Review Booking Agreement: {{ booking_agreement_link }}

--- a/templates/emails/real_estate/booking_agreement_deposit.html
+++ b/templates/emails/real_estate/booking_agreement_deposit.html
@@ -14,6 +14,7 @@
     <p style="margin:0 0 6px;"><strong>Proposed shoot:</strong> {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}</p>
     <p style="margin:0 0 6px;"><strong>Deposit:</strong> {{ deposit_amount|default:"To be confirmed" }}</p>
     <p style="margin:0;"><strong>Balance due:</strong> {{ balance_due|default:"To be confirmed" }}</p>
+    {% if not vat_registered %}<p style="margin:8px 0 0; color:#5F6673; font-size:13px;">{{ vat_notice }}</p>{% endif %}
   </div>
 {% endblock %}
 {% block cta %}

--- a/templates/emails/real_estate/booking_agreement_deposit.txt
+++ b/templates/emails/real_estate/booking_agreement_deposit.txt
@@ -8,6 +8,8 @@ Property: {{ property_address|default:"Not specified" }}
 Proposed shoot: {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}
 Deposit: {{ deposit_amount|default:"To be confirmed" }}
 Balance due: {{ balance_due|default:"To be confirmed" }}
+{% if not vat_registered %}{{ vat_notice }}
+{% endif %}
 
 {% if deposit_payment_link %}Pay Secure Deposit: {{ deposit_payment_link }}
 {% endif %}{% if booking_agreement_link %}Review Booking Agreement: {{ booking_agreement_link }}

--- a/templates/emails/real_estate/deposit_request.html
+++ b/templates/emails/real_estate/deposit_request.html
@@ -14,6 +14,7 @@
     <p style="margin:0 0 6px;"><strong>Proposed shoot:</strong> {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}</p>
     <p style="margin:0 0 6px;"><strong>Deposit:</strong> {{ deposit_amount|default:"To be confirmed" }}</p>
     <p style="margin:0;"><strong>Balance due:</strong> {{ balance_due|default:"To be confirmed" }}</p>
+    {% if not vat_registered %}<p style="margin:8px 0 0; color:#5F6673; font-size:13px;">{{ vat_notice }}</p>{% endif %}
   </div>
 {% endblock %}
 {% block cta %}

--- a/templates/emails/real_estate/deposit_request.txt
+++ b/templates/emails/real_estate/deposit_request.txt
@@ -8,6 +8,8 @@ Property: {{ property_address|default:"Not specified" }}
 Proposed shoot: {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}
 Deposit: {{ deposit_amount|default:"To be confirmed" }}
 Balance due: {{ balance_due|default:"To be confirmed" }}
+{% if not vat_registered %}{{ vat_notice }}
+{% endif %}
 
 {% if deposit_payment_link %}Pay Secure Deposit: {{ deposit_payment_link }}
 {% endif %}{% if booking_agreement_link %}Review Booking Agreement: {{ booking_agreement_link }}

--- a/templates/emails/real_estate/quote.html
+++ b/templates/emails/real_estate/quote.html
@@ -16,19 +16,19 @@
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:16px; border-top:1px solid #E5E7EB;">
         {% if quote_total %}
           <tr>
-            <td style="padding:12px 0 0; color:#5F6673;">Quote total (ex VAT)</td>
+            <td style="padding:12px 0 0; color:#5F6673;">{% if vat_registered and not price_input_is_gross %}Quote total (ex VAT){% else %}Package total{% endif %}</td>
             <td align="right" style="padding:12px 0 0; font-weight:700;">{{ quote_total }}</td>
           </tr>
         {% endif %}
         {% if vat_total %}
           <tr>
-            <td style="padding:8px 0 0; color:#5F6673;">VAT (23%)</td>
+            <td style="padding:8px 0 0; color:#5F6673;">VAT{% if vat_registered %} ({{ vat_rate_percent|floatformat:"-2" }}%){% endif %}</td>
             <td align="right" style="padding:8px 0 0; font-weight:700;">{{ vat_total }}</td>
           </tr>
         {% endif %}
         {% if total_including_vat %}
           <tr>
-            <td style="padding:8px 0 0; color:#5F6673;">Total incl. VAT</td>
+            <td style="padding:8px 0 0; color:#5F6673;">Total payable</td>
             <td align="right" style="padding:8px 0 0; font-weight:800;">{{ total_including_vat }}</td>
           </tr>
         {% endif %}
@@ -44,7 +44,8 @@
             <td align="right" style="padding:8px 0 0; font-weight:700;">{{ balance_due }}</td>
           </tr>
         {% endif %}
-      </table>
+    </table>
+    {% if not vat_registered %}<p style="margin:12px 0 0; color:#5F6673; font-size:13px;">{{ vat_notice }}</p>{% endif %}
     {% endif %}
   </div>
 {% endblock %}

--- a/templates/emails/real_estate/quote.txt
+++ b/templates/emails/real_estate/quote.txt
@@ -8,11 +8,12 @@ Package: {{ package_name|default:"Not specified" }}
 {% if addons %}Add-ons: {% for addon in addons %}{{ addon }}{% if not forloop.last %}; {% endif %}{% endfor %}
 {% endif %}{% if quote_total or vat_total or total_including_vat or deposit_amount or balance_due %}
 Quote summary
-{% if quote_total %}Quote total (ex VAT): {{ quote_total }}
-{% endif %}{% if vat_total %}VAT (23%): {{ vat_total }}
-{% endif %}{% if total_including_vat %}Total incl. VAT: {{ total_including_vat }}
+{% if quote_total %}{% if vat_registered and not price_input_is_gross %}Quote total (ex VAT){% else %}Package total{% endif %}: {{ quote_total }}
+{% endif %}{% if vat_total %}VAT: {{ vat_total }}
+{% endif %}{% if total_including_vat %}Total payable: {{ total_including_vat }}
 {% endif %}{% if deposit_amount %}Deposit required: {{ deposit_amount }}
 {% endif %}{% if balance_due %}Balance on delivery: {{ balance_due }}
+{% endif %}{% if not vat_registered %}{{ vat_notice }}
 {% endif %}{% else %}Quote total: To be confirmed
 {% endif %}
 Ready to proceed?


### PR DESCRIPTION
## Summary

Centralises real-estate VAT configuration and treats advertised or manually entered prices as final customer totals while OpenÉire Studios is not VAT registered. Adds immutable pricing snapshots so historical quotes and existing Stripe deposit sessions retain their original VAT treatment and monetary values.

## Why

OpenÉire Studios is not currently VAT registered, but the real-estate workflow was adding 23% VAT to quotes and calculating deposits from the VAT-inclusive amount.

For new Pro quotes, this changes the calculation to:

- Package total: €399.00
- VAT: €0.00
- Deposit: €119.70
- Balance: €279.30

Historical records must retain their original monetary values and Stripe validation behaviour.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Added central `VAT_REGISTERED`, `VAT_RATE`, and `REALESTATE_PRICE_INPUT_IS_GROSS` settings.
  - Added Decimal-based VAT, total, deposit, and balance calculations.
  - Added immutable monetary snapshots to real-estate enquiries.
  - Added migration `0007_realestate_pricing_snapshots`.
  - Backfilled existing quoted records using the previous 23% net-price calculation.
  - Updated Stripe Checkout deposits to use the stored snapshot amount without tax rates or automatic tax.
  - Updated Stripe webhook validation to use the same persisted snapshot.
  - Updated quote, booking-agreement, and deposit-request email/document wording.
  - Added the supplier-not-VAT-registered notice.
  - Updated `format_money` to accept values such as `EUR 399`.
  - Added VAT-disabled, future VAT-enabled, historical snapshot, API, document, email, and Stripe tests.
- Frontend:
  - None; active frontend changes are in the companion `openeire` PR.
- Infra/Config:
  - Documented the new VAT environment settings.
  - Updated the real-estate email QA checklist.

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally
- [ ] Manual smoke test done

Backend test results:

- Full Django suite: 379 passed.
- Focused real-estate and Stripe webhook suite: 59 passed.
- Real-estate suite: 49 passed.
- Migration drift check: no changes detected.
- Migration `0007` applied successfully to the local database.

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

Recommended pre-release manual checks:

- Generate a new €399 Pro quote and confirm €0 VAT, €119.70 deposit, and €279.30 balance.
- Regenerate a historical quote/agreement and confirm its previous values remain unchanged.
- Open a new Stripe deposit Checkout session and confirm no tax rate is attached.
- Confirm existing unpaid Stripe sessions still validate against their historical snapshots.

## Risk & Rollback

Risk level: Medium

The migration is additive and backfills historical quoted records using the exact previous 23% VAT calculation. Existing quote prices, Stripe session IDs, payment state, and booking state are not altered.

Rollback plan:

- [x] Revert PR
- [x] Feature flag off
- [ ] Hotfix path described:

`VAT_REGISTERED` remains disabled by default. If application behaviour must be rolled back, revert the code while retaining the additive snapshot columns until existing Stripe sessions have drained.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Please pay particular attention to:

- Historical snapshot backfill semantics.
- New gross/final-price behaviour while VAT is disabled.
- Future VAT-enabled gross and net calculation branches.
- Stripe Checkout payloads remaining free of tax configuration.
- Webhook validation using persisted snapshot amounts.
- The fact that no invoice model or balance-payment workflow is introduced.