### PR TITLE
fix(realestate): add guarded invoice void action

### DIFF
--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -24,7 +24,7 @@ from .documents import generate_booking_agreement_pdf
 from .models import RealEstateEnquiry
 from .models import RealEstateTimelineEvent
 from .models import RealEstateDeliveryOverride, RealEstateInvoice, RealEstatePayment
-from .finance import can_release_realestate_delivery, create_realestate_balance_checkout_session, ensure_invoices_for_arrangement, record_realestate_payment, revoke_delivery_override
+from .finance import can_release_realestate_delivery, create_realestate_balance_checkout_session, ensure_invoices_for_arrangement, record_realestate_payment, revoke_delivery_override, void_local_realestate_invoice
 from .stripe_invoices import create_stripe_invoice, mark_stripe_invoice_paid_out_of_band, send_stripe_invoice
 from .payments import calculate_realestate_deposit_amounts
 from .payments import prepare_realestate_deposit_checkout_session
@@ -1740,6 +1740,7 @@ class RealEstateInvoiceAdmin(admin.ModelAdmin):
         "record_manual_payment_action", "download_invoice_pdf",
         "create_stripe_invoice_action", "create_and_send_stripe_invoice_action",
         "send_stripe_reminder_action", "mark_stripe_paid_out_of_band_action",
+        "void_local_invoices_action",
     )
 
     @admin.display(description="Amount paid")
@@ -1775,6 +1776,44 @@ class RealEstateInvoiceAdmin(admin.ModelAdmin):
         actions = super().get_actions(request)
         actions.pop("delete_selected", None)
         return actions
+
+    @admin.action(
+        description="Void selected unpaid local-only invoices",
+        permissions=("change",),
+    )
+    def void_local_invoices_action(self, request, queryset):
+        if "confirm_void_local_invoices" not in request.POST:
+            return TemplateResponse(
+                request,
+                "admin/realestate/void_local_invoices.html",
+                {
+                    **self.admin_site.each_context(request),
+                    "invoices": queryset.select_related("enquiry"),
+                    "title": "Confirm invoice void",
+                },
+            )
+
+        voided_count = 0
+        for invoice in queryset.select_related("enquiry"):
+            try:
+                _invoice, changed = void_local_realestate_invoice(
+                    invoice,
+                    user=request.user,
+                )
+            except (ValidationError, PermissionDenied) as exc:
+                self.message_user(
+                    request,
+                    f"{invoice.invoice_number}: {exc}",
+                    level=messages.ERROR,
+                )
+            else:
+                voided_count += int(changed)
+        if voided_count:
+            self.message_user(
+                request,
+                f"Voided {voided_count} local invoice(s).",
+                level=messages.SUCCESS,
+            )
 
     @admin.action(description="Create Stripe invoice")
     def create_stripe_invoice_action(self, request, queryset):

--- a/realestate/finance.py
+++ b/realestate/finance.py
@@ -144,6 +144,68 @@ def ensure_invoices_for_arrangement(enquiry):
     raise ValidationError("Unsupported payment arrangement.")
 
 
+@transaction.atomic
+def void_local_realestate_invoice(invoice, *, user=None):
+    """Void an unpaid invoice only when no external payment object can remain live."""
+    invoice = (
+        RealEstateInvoice.objects.select_for_update()
+        .select_related("enquiry")
+        .get(pk=invoice.pk)
+    )
+    if invoice.status == RealEstateInvoice.Status.VOID:
+        return invoice, False
+    if invoice.status in {
+        RealEstateInvoice.Status.PARTIALLY_PAID,
+        RealEstateInvoice.Status.PAID,
+    }:
+        raise ValidationError("Paid or partially paid invoices cannot be voided.")
+    if invoice.payments.exists():
+        raise ValidationError(
+            "Invoices with payment records cannot be voided from this admin action."
+        )
+
+    stripe_references = (
+        invoice.stripe_invoice_id,
+        invoice.stripe_invoice_number,
+        invoice.stripe_hosted_invoice_url,
+        invoice.stripe_invoice_pdf_url,
+        invoice.stripe_checkout_session_id,
+        invoice.stripe_checkout_url,
+    )
+    if any(str(value or "").strip() for value in stripe_references):
+        raise ValidationError(
+            "This invoice has Stripe references. Verify and void the Stripe object "
+            "before changing the local invoice."
+        )
+    if (
+        invoice.invoice_type == RealEstateInvoice.InvoiceType.DEPOSIT
+        and (
+            str(invoice.enquiry.stripe_deposit_session_id or "").strip()
+            or str(invoice.enquiry.deposit_payment_link or "").strip()
+        )
+    ):
+        raise ValidationError(
+            "This deposit invoice belongs to an enquiry with a saved Stripe Checkout "
+            "Session. Expire or reconcile that Session before voiding the invoice."
+        )
+
+    invoice.status = RealEstateInvoice.Status.VOID
+    invoice.save(update_fields=("status", "updated_at"))
+    record_timeline_event(
+        invoice.enquiry,
+        RealEstateTimelineEvent.EventType.NOTE,
+        actor_type=(
+            RealEstateTimelineEvent.ActorType.ADMIN
+            if user
+            else RealEstateTimelineEvent.ActorType.SYSTEM
+        ),
+        title="Invoice voided",
+        notes=f"Invoice {invoice.invoice_number} was voided without a payment record.",
+        created_by=user,
+    )
+    return invoice, True
+
+
 def _successful_total(invoice):
     return invoice.payments.filter(status=RealEstatePayment.Status.SUCCEEDED).aggregate(
         value=Sum("amount")

--- a/realestate/test_finance.py
+++ b/realestate/test_finance.py
@@ -24,9 +24,10 @@ from .finance import (
     grant_delivery_override,
     record_realestate_payment,
     revoke_delivery_override,
+    void_local_realestate_invoice,
 )
 from .stripe_invoices import create_stripe_invoice, mark_stripe_invoice_paid_out_of_band
-from .admin import RealEstateEnquiryAdmin
+from .admin import RealEstateEnquiryAdmin, RealEstateInvoiceAdmin
 from openeire_api.admin import custom_admin_site
 from .financial_documents import (
     build_invoice_filename,
@@ -67,6 +68,93 @@ class RealEstateFinanceTests(TestCase):
         self.deposit.total = Decimal("1.00")
         with self.assertRaises(ValidationError):
             self.deposit.save()
+
+    def test_unpaid_local_invoice_can_be_voided_with_audit_event(self):
+        invoice, changed = void_local_realestate_invoice(
+            self.deposit,
+            user=self.staff,
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(invoice.status, RealEstateInvoice.Status.VOID)
+        event = self.enquiry.timeline_events.get(title="Invoice voided")
+        self.assertEqual(event.actor_type, RealEstateTimelineEvent.ActorType.ADMIN)
+        self.assertEqual(event.created_by, self.staff)
+        self.assertIn(self.deposit.invoice_number, event.notes)
+
+        _invoice, changed_again = void_local_realestate_invoice(
+            invoice,
+            user=self.staff,
+        )
+        self.assertFalse(changed_again)
+        self.assertEqual(self.enquiry.timeline_events.filter(title="Invoice voided").count(), 1)
+
+    def test_invoice_with_any_payment_record_cannot_be_voided(self):
+        record_realestate_payment(
+            invoice=self.deposit,
+            amount="10.00",
+            method=RealEstatePayment.Method.OTHER,
+            paid_at=timezone.now(),
+            status=RealEstatePayment.Status.FAILED,
+            notes="Test failure record",
+        )
+
+        with self.assertRaisesMessage(ValidationError, "payment records"):
+            void_local_realestate_invoice(self.deposit, user=self.staff)
+
+    def test_invoice_with_stripe_reference_cannot_be_voided(self):
+        self.deposit.stripe_invoice_id = "in_test_existing"
+        self.deposit.save(update_fields=("stripe_invoice_id", "updated_at"))
+
+        with self.assertRaisesMessage(ValidationError, "Stripe references"):
+            void_local_realestate_invoice(self.deposit, user=self.staff)
+
+    def test_deposit_invoice_with_saved_checkout_cannot_be_voided(self):
+        self.enquiry.stripe_deposit_session_id = "cs_test_existing"
+        self.enquiry.deposit_payment_link = "https://checkout.stripe.com/test"
+        self.enquiry.save(
+            update_fields=(
+                "stripe_deposit_session_id",
+                "deposit_payment_link",
+                "updated_at",
+            )
+        )
+
+        with self.assertRaisesMessage(ValidationError, "saved Stripe Checkout Session"):
+            void_local_realestate_invoice(self.deposit, user=self.staff)
+
+    def test_invoice_admin_void_action_requires_confirmation_and_voids(self):
+        model_admin = RealEstateInvoiceAdmin(RealEstateInvoice, custom_admin_site)
+        request = RequestFactory().post("/admin/realestate/invoices/")
+        request.user = self.staff
+
+        confirmation = model_admin.void_local_invoices_action(
+            request,
+            RealEstateInvoice.objects.filter(pk=self.deposit.pk),
+        )
+
+        self.assertEqual(
+            confirmation.template_name,
+            "admin/realestate/void_local_invoices.html",
+        )
+        self.deposit.refresh_from_db()
+        self.assertEqual(self.deposit.status, RealEstateInvoice.Status.ISSUED)
+
+        confirmed_request = RequestFactory().post(
+            "/admin/realestate/invoices/",
+            {"confirm_void_local_invoices": "1"},
+        )
+        confirmed_request.user = self.staff
+        model_admin.message_user = Mock()
+
+        model_admin.void_local_invoices_action(
+            confirmed_request,
+            RealEstateInvoice.objects.filter(pk=self.deposit.pk),
+        )
+
+        self.deposit.refresh_from_db()
+        self.assertEqual(self.deposit.status, RealEstateInvoice.Status.VOID)
+        model_admin.message_user.assert_called_once()
 
     def test_partial_cash_and_bank_balance_and_overpayment(self):
         cash, _ = record_realestate_payment(

--- a/templates/admin/realestate/void_local_invoices.html
+++ b/templates/admin/realestate/void_local_invoices.html
@@ -1,0 +1,23 @@
+{% extends "admin/base_site.html" %}
+{% block content %}
+<p>
+  This marks the selected invoices as void while preserving their audit history.
+  Only unpaid invoices without payment records, Stripe invoice references, or saved
+  Checkout Sessions can be voided here.
+</p>
+<p><strong>This does not delete the invoice or reuse its invoice number.</strong></p>
+<ul>
+  {% for invoice in invoices %}
+    <li>{{ invoice.invoice_number }} — {{ invoice.enquiry }} — {{ invoice.get_status_display }}</li>
+  {% endfor %}
+</ul>
+<form method="post">{% csrf_token %}
+  <input type="hidden" name="action" value="void_local_invoices_action">
+  {% for invoice in invoices %}
+    <input type="hidden" name="_selected_action" value="{{ invoice.pk }}">
+  {% endfor %}
+  <button type="submit" name="confirm_void_local_invoices" value="1">
+    Confirm void
+  </button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds a guarded Django Admin action for voiding unpaid, local-only real-estate test invoices while preserving invoice numbers and the financial audit trail.

## Why

Issued invoices are intentionally not deletable in Django Admin, even for superusers. That protection is correct for financial records, but staff had no safe way to clean up local test invoices that were never paid and never created in Stripe.

A read-only check of the connected OpenÉire Studios Stripe account returned zero Stripe Billing invoices. This PR adds a controlled void workflow instead of weakening invoice deletion protections.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Added `void_local_realestate_invoice()` with row-level locking and idempotent behavior.
  - Allows voiding only unpaid invoices with no payment records.
  - Refuses invoices with Stripe invoice or Checkout references.
  - Refuses deposit invoices when the enquiry retains a saved Stripe Checkout Session or payment link.
  - Records an “Invoice voided” timeline audit event.
  - Added a Django Admin bulk action with an explicit confirmation page.
  - Preserved invoice numbers and existing delete restrictions.
  - Added regression coverage for successful voiding, repeated requests, payment guards, Stripe-reference guards, saved Checkout guards, and admin confirmation.
- Frontend:
  - No public frontend changes.
  - Added a Django Admin confirmation template.
- Infra/Config:
  - No migration or configuration changes.

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally — not applicable
- [x] Manual smoke test done

Commands and results:

- `python manage.py check` — passed
- Focused finance/admin tests — 48 passed
- `python manage.py test realestate` — 123 passed
- `python manage.py test` — 455 passed
- `git diff --check` — passed

### Manual smoke test checklist (quick)

- [x] Admin action requires confirmation
- [x] Eligible unpaid local invoice becomes void
- [x] Repeated void is idempotent
- [x] Payment records block the action
- [x] Stripe references block the action
- [x] Saved deposit Checkout Sessions block the action
- [x] Timeline audit event is recorded
- [ ] Mobile layout checked — not applicable
- [x] Auth/permissions verified — action requires invoice change permission

## Risk & Rollback

Risk level: Low

The action is additive and only changes an invoice after explicit staff selection and confirmation. It is intentionally fail-closed whenever payment or Stripe state exists.

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described: revert the commit; no schema or data migration is involved. Already-voided invoices remain valid audit records.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Please focus on the fail-closed Stripe/payment guards, transactional row lock, idempotency, and preservation of the financial audit trail.