### PR TITLE
fix(realestate): safely clear expired test deposit sessions

### DIFF
--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -1800,7 +1800,13 @@ class RealEstateInvoiceAdmin(admin.ModelAdmin):
                     invoice,
                     user=request.user,
                 )
-            except (ValidationError, PermissionDenied) as exc:
+            except ValidationError as exc:
+                self.message_user(
+                    request,
+                    f"{invoice.invoice_number}: {' '.join(exc.messages)}",
+                    level=messages.ERROR,
+                )
+            except PermissionDenied as exc:
                 self.message_user(
                     request,
                     f"{invoice.invoice_number}: {exc}",

--- a/realestate/finance.py
+++ b/realestate/finance.py
@@ -1,3 +1,4 @@
+import logging
 from decimal import Decimal, ROUND_HALF_UP
 from datetime import datetime, time
 
@@ -24,6 +25,7 @@ from .timeline import record_timeline_event
 
 
 MONEY = Decimal("0.01")
+logger = logging.getLogger(__name__)
 
 
 def money(value):
@@ -144,66 +146,208 @@ def ensure_invoices_for_arrangement(enquiry):
     raise ValidationError("Unsupported payment arrangement.")
 
 
-@transaction.atomic
+def _stripe_value(obj, key, default=None):
+    if hasattr(obj, "get"):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _verify_expired_test_deposit_session(invoice):
+    enquiry = invoice.enquiry
+    session_id = str(enquiry.stripe_deposit_session_id or "").strip()
+    checkout_url = str(enquiry.deposit_payment_link or "").strip()
+    if not session_id and not checkout_url:
+        return ""
+    if not session_id:
+        raise ValidationError(
+            "This enquiry has a saved deposit link without a Stripe Session ID. "
+            "It requires manual review."
+        )
+
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+    stripe.max_network_retries = getattr(settings, "STRIPE_MAX_NETWORK_RETRIES", 2)
+    try:
+        session = stripe.checkout.Session.retrieve(session_id)
+    except Exception as exc:
+        logger.exception(
+            "Could not verify saved test deposit Checkout Session before invoice void. "
+            "enquiry_id=%s invoice_id=%s session_id=%s",
+            enquiry.pk,
+            invoice.pk,
+            session_id,
+        )
+        raise ValidationError(
+            "The saved Stripe Checkout Session could not be retrieved. No local "
+            "payment references were changed."
+        ) from exc
+
+    metadata = _stripe_value(session, "metadata", {}) or {}
+    expected_invoice_number = str(metadata.get("realestate_invoice_number") or "").strip()
+    validation_errors = []
+    if str(_stripe_value(session, "id", "") or "").strip() != session_id:
+        validation_errors.append("Session ID")
+    if _stripe_value(session, "livemode") is not False:
+        validation_errors.append("environment")
+    if str(_stripe_value(session, "status", "") or "").lower() != "expired":
+        validation_errors.append("status")
+    if str(_stripe_value(session, "payment_status", "") or "").lower() != "unpaid":
+        validation_errors.append("payment status")
+    if str(_stripe_value(session, "currency", "") or "").lower() != "eur":
+        validation_errors.append("currency")
+    if str(metadata.get("purpose") or "").strip() != "realestate_deposit":
+        validation_errors.append("purpose metadata")
+    if str(metadata.get("realestate_enquiry_id") or "").strip() != str(enquiry.pk):
+        validation_errors.append("enquiry metadata")
+    if expected_invoice_number and expected_invoice_number != invoice.invoice_number:
+        validation_errors.append("invoice metadata")
+    if str(_stripe_value(session, "recovered_from", "") or "").strip():
+        validation_errors.append("recovered Session")
+    created = _stripe_value(session, "created")
+    if not created:
+        validation_errors.append("creation timestamp")
+    if validation_errors:
+        raise ValidationError(
+            "The saved Stripe Checkout Session is not an expired, unpaid, matching "
+            f"test deposit Session ({', '.join(validation_errors)})."
+        )
+
+    try:
+        later_sessions = stripe.checkout.Session.list(
+            limit=100,
+            created={"gte": int(created)},
+        )
+        has_recovery = any(
+            str(_stripe_value(candidate, "recovered_from", "") or "").strip()
+            == session_id
+            for candidate in later_sessions.auto_paging_iter()
+        )
+    except Exception as exc:
+        logger.exception(
+            "Could not check for recovered test deposit Checkout Sessions before "
+            "invoice void. enquiry_id=%s invoice_id=%s session_id=%s",
+            enquiry.pk,
+            invoice.pk,
+            session_id,
+        )
+        raise ValidationError(
+            "Stripe recovery status could not be verified. No local payment "
+            "references were changed."
+        ) from exc
+    if has_recovery:
+        raise ValidationError(
+            "A recovery-created Stripe Checkout Session exists for this deposit. "
+            "It must be reviewed before the invoice can be voided."
+        )
+
+    return session_id
+
+
 def void_local_realestate_invoice(invoice, *, user=None):
     """Void an unpaid invoice only when no external payment object can remain live."""
-    invoice = (
-        RealEstateInvoice.objects.select_for_update()
+    candidate = (
+        RealEstateInvoice.objects
         .select_related("enquiry")
         .get(pk=invoice.pk)
     )
-    if invoice.status == RealEstateInvoice.Status.VOID:
-        return invoice, False
-    if invoice.status in {
-        RealEstateInvoice.Status.PARTIALLY_PAID,
-        RealEstateInvoice.Status.PAID,
-    }:
-        raise ValidationError("Paid or partially paid invoices cannot be voided.")
-    if invoice.payments.exists():
-        raise ValidationError(
-            "Invoices with payment records cannot be voided from this admin action."
-        )
-
-    stripe_references = (
-        invoice.stripe_invoice_id,
-        invoice.stripe_invoice_number,
-        invoice.stripe_hosted_invoice_url,
-        invoice.stripe_invoice_pdf_url,
-        invoice.stripe_checkout_session_id,
-        invoice.stripe_checkout_url,
-    )
-    if any(str(value or "").strip() for value in stripe_references):
-        raise ValidationError(
-            "This invoice has Stripe references. Verify and void the Stripe object "
-            "before changing the local invoice."
-        )
+    verified_session_id = ""
     if (
-        invoice.invoice_type == RealEstateInvoice.InvoiceType.DEPOSIT
+        candidate.status != RealEstateInvoice.Status.VOID
+        and candidate.invoice_type == RealEstateInvoice.InvoiceType.DEPOSIT
         and (
-            str(invoice.enquiry.stripe_deposit_session_id or "").strip()
-            or str(invoice.enquiry.deposit_payment_link or "").strip()
+            str(candidate.enquiry.stripe_deposit_session_id or "").strip()
+            or str(candidate.enquiry.deposit_payment_link or "").strip()
         )
     ):
-        raise ValidationError(
-            "This deposit invoice belongs to an enquiry with a saved Stripe Checkout "
-            "Session. Expire or reconcile that Session before voiding the invoice."
-        )
+        verified_session_id = _verify_expired_test_deposit_session(candidate)
 
-    invoice.status = RealEstateInvoice.Status.VOID
-    invoice.save(update_fields=("status", "updated_at"))
-    record_timeline_event(
-        invoice.enquiry,
-        RealEstateTimelineEvent.EventType.NOTE,
-        actor_type=(
-            RealEstateTimelineEvent.ActorType.ADMIN
-            if user
-            else RealEstateTimelineEvent.ActorType.SYSTEM
-        ),
-        title="Invoice voided",
-        notes=f"Invoice {invoice.invoice_number} was voided without a payment record.",
-        created_by=user,
-    )
-    return invoice, True
+    with transaction.atomic():
+        invoice = (
+            RealEstateInvoice.objects.select_for_update()
+            .select_related("enquiry")
+            .get(pk=candidate.pk)
+        )
+        if invoice.status == RealEstateInvoice.Status.VOID:
+            return invoice, False
+        if invoice.status in {
+            RealEstateInvoice.Status.PARTIALLY_PAID,
+            RealEstateInvoice.Status.PAID,
+        }:
+            raise ValidationError("Paid or partially paid invoices cannot be voided.")
+        if invoice.payments.exists():
+            raise ValidationError(
+                "Invoices with payment records cannot be voided from this admin action."
+            )
+
+        stripe_references = (
+            invoice.stripe_invoice_id,
+            invoice.stripe_invoice_number,
+            invoice.stripe_hosted_invoice_url,
+            invoice.stripe_invoice_pdf_url,
+            invoice.stripe_checkout_session_id,
+            invoice.stripe_checkout_url,
+        )
+        if any(str(value or "").strip() for value in stripe_references):
+            raise ValidationError(
+                "This invoice has Stripe references. Verify and void the Stripe object "
+                "before changing the local invoice."
+            )
+
+        cleared_session_id = ""
+        if invoice.invoice_type == RealEstateInvoice.InvoiceType.DEPOSIT:
+            current_session_id = str(
+                invoice.enquiry.stripe_deposit_session_id or ""
+            ).strip()
+            current_checkout_url = str(
+                invoice.enquiry.deposit_payment_link or ""
+            ).strip()
+            if current_session_id or current_checkout_url:
+                if not verified_session_id or current_session_id != verified_session_id:
+                    raise ValidationError(
+                        "The saved deposit Checkout Session changed during Stripe "
+                        "verification. Retry after reviewing the enquiry."
+                    )
+                invoice.enquiry.deposit_payment_link = ""
+                invoice.enquiry.stripe_deposit_session_id = ""
+                invoice.enquiry.stripe_deposit_creation_key = ""
+                invoice.enquiry.save(
+                    update_fields=(
+                        "deposit_payment_link",
+                        "stripe_deposit_session_id",
+                        "stripe_deposit_creation_key",
+                        "updated_at",
+                    )
+                )
+                cleared_session_id = verified_session_id
+            elif verified_session_id:
+                raise ValidationError(
+                    "The saved deposit Checkout Session changed during Stripe "
+                    "verification. Retry after reviewing the enquiry."
+                )
+
+        invoice.status = RealEstateInvoice.Status.VOID
+        invoice.save(update_fields=("status", "updated_at"))
+        record_timeline_event(
+            invoice.enquiry,
+            RealEstateTimelineEvent.EventType.NOTE,
+            actor_type=(
+                RealEstateTimelineEvent.ActorType.ADMIN
+                if user
+                else RealEstateTimelineEvent.ActorType.SYSTEM
+            ),
+            title="Invoice voided",
+            notes=f"Invoice {invoice.invoice_number} was voided without a payment record.",
+            stripe_session_id=cleared_session_id,
+            created_by=user,
+        )
+        if cleared_session_id:
+            logger.info(
+                "Cleared verified expired unpaid test deposit Checkout Session before "
+                "invoice void. enquiry_id=%s invoice_id=%s session_id=%s",
+                invoice.enquiry_id,
+                invoice.pk,
+                cleared_session_id,
+            )
+        return invoice, True
 
 
 def _successful_total(invoice):

--- a/realestate/test_finance.py
+++ b/realestate/test_finance.py
@@ -53,6 +53,29 @@ class RealEstateFinanceTests(TestCase):
         self.deposit, self.balance = ensure_standard_realestate_invoices(self.enquiry)
         self.staff = get_user_model().objects.create_user("staff", is_staff=True)
 
+    def _expired_test_deposit_session(self, **overrides):
+        values = {
+            "id": "cs_test_existing",
+            "livemode": False,
+            "status": "expired",
+            "payment_status": "unpaid",
+            "currency": "eur",
+            "created": int(timezone.now().timestamp()) - 86400,
+            "recovered_from": None,
+            "metadata": {
+                "purpose": "realestate_deposit",
+                "realestate_enquiry_id": str(self.enquiry.pk),
+                "realestate_invoice_number": self.deposit.invoice_number,
+            },
+        }
+        values.update(overrides)
+        return values
+
+    def _stripe_session_list(self, *sessions):
+        result = Mock()
+        result.auto_paging_iter.return_value = iter(sessions)
+        return result
+
     def test_snapshot_and_invoice_amounts(self):
         self.assertEqual(self.enquiry.quoted_deposit_amount, Decimal("119.70"))
         self.assertEqual(self.enquiry.quoted_balance_due, Decimal("279.30"))
@@ -109,7 +132,155 @@ class RealEstateFinanceTests(TestCase):
         with self.assertRaisesMessage(ValidationError, "Stripe references"):
             void_local_realestate_invoice(self.deposit, user=self.staff)
 
-    def test_deposit_invoice_with_saved_checkout_cannot_be_voided(self):
+    @patch("realestate.finance.stripe.checkout.Session.list")
+    @patch("realestate.finance.stripe.checkout.Session.retrieve")
+    def test_verified_expired_unpaid_test_checkout_is_cleared_before_void(
+        self,
+        mock_retrieve,
+        mock_list,
+    ):
+        self.enquiry.stripe_deposit_session_id = "cs_test_existing"
+        self.enquiry.deposit_payment_link = "https://checkout.stripe.com/test"
+        self.enquiry.stripe_deposit_creation_key = "realestate-test-attempt"
+        self.enquiry.save(
+            update_fields=(
+                "stripe_deposit_session_id",
+                "deposit_payment_link",
+                "stripe_deposit_creation_key",
+                "updated_at",
+            )
+        )
+        session = self._expired_test_deposit_session()
+        session["metadata"]["realestate_invoice_number"] = None
+        mock_retrieve.return_value = session
+        mock_list.return_value = self._stripe_session_list()
+
+        invoice, changed = void_local_realestate_invoice(
+            self.deposit,
+            user=self.staff,
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(invoice.status, RealEstateInvoice.Status.VOID)
+        self.enquiry.refresh_from_db()
+        self.assertEqual(self.enquiry.stripe_deposit_session_id, "")
+        self.assertEqual(self.enquiry.deposit_payment_link, "")
+        self.assertEqual(self.enquiry.stripe_deposit_creation_key, "")
+        event = self.enquiry.timeline_events.get(title="Invoice voided")
+        self.assertEqual(event.stripe_session_id, "cs_test_existing")
+        mock_retrieve.assert_called_once_with("cs_test_existing")
+        mock_list.assert_called_once_with(limit=100, created={"gte": session["created"]})
+
+    @patch("realestate.finance.stripe.checkout.Session.list")
+    @patch("realestate.finance.stripe.checkout.Session.retrieve")
+    def test_unsafe_or_mismatched_checkout_cannot_be_cleared_or_voided(
+        self,
+        mock_retrieve,
+        mock_list,
+    ):
+        self.enquiry.stripe_deposit_session_id = "cs_test_existing"
+        self.enquiry.deposit_payment_link = "https://checkout.stripe.com/test"
+        self.enquiry.save(
+            update_fields=(
+                "stripe_deposit_session_id",
+                "deposit_payment_link",
+                "updated_at",
+            )
+        )
+        mock_list.return_value = self._stripe_session_list()
+        cases = {
+            "live": {"livemode": True},
+            "paid": {"payment_status": "paid"},
+            "open": {"status": "open"},
+            "recovered": {"recovered_from": "cs_test_original"},
+            "wrong currency": {"currency": "usd"},
+            "wrong id": {"id": "cs_test_other"},
+            "missing created": {"created": None},
+            "wrong purpose": {
+                "metadata": {
+                    "purpose": "other",
+                    "realestate_enquiry_id": str(self.enquiry.pk),
+                    "realestate_invoice_number": self.deposit.invoice_number,
+                }
+            },
+            "wrong enquiry": {
+                "metadata": {
+                    "purpose": "realestate_deposit",
+                    "realestate_enquiry_id": "999",
+                    "realestate_invoice_number": self.deposit.invoice_number,
+                }
+            },
+            "wrong invoice": {
+                "metadata": {
+                    "purpose": "realestate_deposit",
+                    "realestate_enquiry_id": str(self.enquiry.pk),
+                    "realestate_invoice_number": "OE-RE-2099-9999",
+                }
+            },
+        }
+
+        for label, overrides in cases.items():
+            with self.subTest(label=label):
+                mock_retrieve.return_value = self._expired_test_deposit_session(
+                    **overrides
+                )
+                with self.assertRaisesMessage(ValidationError, "not an expired"):
+                    void_local_realestate_invoice(self.deposit, user=self.staff)
+
+        self.enquiry.refresh_from_db()
+        self.deposit.refresh_from_db()
+        self.assertEqual(self.enquiry.stripe_deposit_session_id, "cs_test_existing")
+        self.assertEqual(
+            self.enquiry.deposit_payment_link,
+            "https://checkout.stripe.com/test",
+        )
+        self.assertEqual(self.deposit.status, RealEstateInvoice.Status.ISSUED)
+        mock_list.assert_not_called()
+
+    @patch("realestate.finance.stripe.checkout.Session.retrieve")
+    def test_missing_checkout_session_fails_closed(self, mock_retrieve):
+        self.enquiry.stripe_deposit_session_id = "cs_test_missing"
+        self.enquiry.deposit_payment_link = "https://checkout.stripe.com/test"
+        self.enquiry.save(
+            update_fields=(
+                "stripe_deposit_session_id",
+                "deposit_payment_link",
+                "updated_at",
+            )
+        )
+        mock_retrieve.side_effect = RuntimeError("No such Checkout Session")
+
+        with self.assertRaisesMessage(ValidationError, "could not be retrieved"):
+            void_local_realestate_invoice(self.deposit, user=self.staff)
+
+        self.deposit.refresh_from_db()
+        self.assertEqual(self.deposit.status, RealEstateInvoice.Status.ISSUED)
+
+    @patch("realestate.finance.stripe.checkout.Session.list")
+    @patch("realestate.finance.stripe.checkout.Session.retrieve")
+    def test_recovery_created_checkout_blocks_void(self, mock_retrieve, mock_list):
+        self.enquiry.stripe_deposit_session_id = "cs_test_existing"
+        self.enquiry.deposit_payment_link = "https://checkout.stripe.com/test"
+        self.enquiry.save(
+            update_fields=(
+                "stripe_deposit_session_id",
+                "deposit_payment_link",
+                "updated_at",
+            )
+        )
+        mock_retrieve.return_value = self._expired_test_deposit_session()
+        mock_list.return_value = self._stripe_session_list(
+            {"id": "cs_test_recovered", "recovered_from": "cs_test_existing"}
+        )
+
+        with self.assertRaisesMessage(ValidationError, "recovery-created"):
+            void_local_realestate_invoice(self.deposit, user=self.staff)
+
+    @patch("realestate.finance._verify_expired_test_deposit_session")
+    def test_checkout_reference_change_during_verification_fails_closed(
+        self,
+        mock_verify,
+    ):
         self.enquiry.stripe_deposit_session_id = "cs_test_existing"
         self.enquiry.deposit_payment_link = "https://checkout.stripe.com/test"
         self.enquiry.save(
@@ -120,8 +291,25 @@ class RealEstateFinanceTests(TestCase):
             )
         )
 
-        with self.assertRaisesMessage(ValidationError, "saved Stripe Checkout Session"):
+        def replace_saved_session(_invoice):
+            RealEstateEnquiry.objects.filter(pk=self.enquiry.pk).update(
+                stripe_deposit_session_id="cs_test_replacement",
+                deposit_payment_link="https://checkout.stripe.com/replacement",
+            )
+            return "cs_test_existing"
+
+        mock_verify.side_effect = replace_saved_session
+
+        with self.assertRaisesMessage(ValidationError, "changed during Stripe"):
             void_local_realestate_invoice(self.deposit, user=self.staff)
+
+        self.deposit.refresh_from_db()
+        self.enquiry.refresh_from_db()
+        self.assertEqual(self.deposit.status, RealEstateInvoice.Status.ISSUED)
+        self.assertEqual(
+            self.enquiry.stripe_deposit_session_id,
+            "cs_test_replacement",
+        )
 
     def test_invoice_admin_void_action_requires_confirmation_and_voids(self):
         model_admin = RealEstateInvoiceAdmin(RealEstateInvoice, custom_admin_site)
@@ -155,6 +343,31 @@ class RealEstateFinanceTests(TestCase):
         self.deposit.refresh_from_db()
         self.assertEqual(self.deposit.status, RealEstateInvoice.Status.VOID)
         model_admin.message_user.assert_called_once()
+
+    @patch(
+        "realestate.admin.void_local_realestate_invoice",
+        side_effect=ValidationError("Stripe verification failed."),
+    )
+    def test_invoice_admin_formats_void_validation_error_cleanly(self, _mock_void):
+        model_admin = RealEstateInvoiceAdmin(RealEstateInvoice, custom_admin_site)
+        request = RequestFactory().post(
+            "/admin/realestate/invoices/",
+            {"confirm_void_local_invoices": "1"},
+        )
+        request.user = self.staff
+        model_admin.message_user = Mock()
+
+        model_admin.void_local_invoices_action(
+            request,
+            RealEstateInvoice.objects.filter(pk=self.deposit.pk),
+        )
+
+        message = model_admin.message_user.call_args.args[1]
+        self.assertEqual(
+            message,
+            f"{self.deposit.invoice_number}: Stripe verification failed.",
+        )
+        self.assertNotIn("['", message)
 
     def test_partial_cash_and_bank_balance_and_overpayment(self):
         cash, _ = record_realestate_payment(

--- a/templates/admin/realestate/void_local_invoices.html
+++ b/templates/admin/realestate/void_local_invoices.html
@@ -2,8 +2,10 @@
 {% block content %}
 <p>
   This marks the selected invoices as void while preserving their audit history.
-  Only unpaid invoices without payment records, Stripe invoice references, or saved
-  Checkout Sessions can be voided here.
+  Only unpaid invoices without payment records or Stripe invoice references can be
+  voided here. A saved deposit Checkout Session is cleared automatically only when
+  Stripe confirms that it is an expired, unpaid, matching test-mode Session with no
+  recovery-created Session.
 </p>
 <p><strong>This does not delete the invoice or reuse its invoice number.</strong></p>
 <ul>


### PR DESCRIPTION
## Summary

Extends the guarded real-estate invoice void action so it can safely clear stale deposit Checkout references when Stripe verifies that the exact saved Session is an expired, unpaid, matching test-mode Session with no recovery-created child.

## Why

Two local test deposit invoices could not be voided because their enquiries retained stale Stripe Checkout Session IDs and raw Checkout links from earlier deposit-email tests. The Sessions were absent from Stripe Billing because they were Checkout Sessions; read-only Stripe inspection confirmed they were test-mode, expired and unpaid.

The existing fail-closed guard correctly blocked the operation, but staff had no safe admin workflow for verifying and clearing those stale test references.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Retrieves the exact saved Checkout Session before voiding a deposit invoice.
  - Requires test mode, expired status, unpaid payment status and EUR currency.
  - Verifies real-estate deposit purpose and matching enquiry metadata.
  - Accepts legacy test Sessions without invoice-number metadata, while rejecting a mismatched invoice number when present.
  - Rejects live, open, paid, recovered, missing and metadata-mismatched Sessions.
  - Searches all later Checkout Sessions for a recovery-created child and fails closed if one exists.
  - Performs Stripe network reads before acquiring the database row lock.
  - Re-locks and revalidates invoice, payment, Stripe-reference and saved Session state before clearing anything.
  - Atomically clears `deposit_payment_link`, `stripe_deposit_session_id` and `stripe_deposit_creation_key`.
  - Stores the cleared Session ID on the invoice-void timeline event and logs only safe identifiers.
  - Formats admin validation errors as clean messages rather than Python lists.
- Frontend:
  - Updated the Django Admin confirmation text to explain verified test-Session cleanup.
- Infra/Config:
  - No migrations or configuration changes.

## Testing

- [x] Django tests pass locally
- [ ] React build passes locally — not applicable
- [x] Manual smoke test done

Commands and results:

- `python manage.py makemigrations --check` — no changes detected
- `python manage.py check` — passed
- Focused finance tests — 30 passed
- `python manage.py test realestate` — 127 passed
- `python manage.py test` — 459 passed
- `git diff --check` — passed
- Read-only Stripe inspection confirmed the affected Sessions were test-mode, expired and unpaid

### Manual smoke test checklist (quick)

- [x] Valid expired/unpaid test Session is cleared before invoice void
- [x] Legacy metadata without invoice number is supported
- [x] Live, paid and open Sessions are rejected
- [x] Recovered and recovery-created Sessions are rejected
- [x] Missing and mismatched Sessions fail closed
- [x] Concurrent saved-Session changes fail closed
- [x] Payment and invoice-level Stripe references remain protected
- [x] Audit event records the cleared Session ID
- [x] Admin errors render cleanly
- [ ] Mobile layout checked — not applicable
- [x] Auth/permissions verified — existing invoice change permission remains required

## Risk & Rollback

Risk level: Medium

The action performs read-only Stripe API calls and changes local financial state only after strict test-mode verification. Stripe failures and uncertain state are fail-closed. Database state is rechecked transactionally after the external API calls.

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described: revert the commit; no migration is involved. Invoices already voided through the verified workflow remain valid audit records.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Please focus on the test-mode-only constraint, recovery-child scan, metadata association, two-phase Stripe/database concurrency handling, idempotency, and fail-closed behavior.