### PR TITLE
fix(realestate): allow voiding expired live deposit sessions

### DIFF
--- a/realestate/finance.py
+++ b/realestate/finance.py
@@ -152,7 +152,17 @@ def _stripe_value(obj, key, default=None):
     return getattr(obj, key, default)
 
 
-def _verify_expired_test_deposit_session(invoice):
+def _has_matching_checkout_environment(session, session_id):
+    """Require Stripe's explicit mode to agree with the Session identifier."""
+    livemode = _stripe_value(session, "livemode")
+    if livemode is True:
+        return session_id.startswith("cs_live_")
+    if livemode is False:
+        return session_id.startswith("cs_test_")
+    return False
+
+
+def _verify_expired_deposit_session(invoice):
     enquiry = invoice.enquiry
     session_id = str(enquiry.stripe_deposit_session_id or "").strip()
     checkout_url = str(enquiry.deposit_payment_link or "").strip()
@@ -170,7 +180,7 @@ def _verify_expired_test_deposit_session(invoice):
         session = stripe.checkout.Session.retrieve(session_id)
     except Exception as exc:
         logger.exception(
-            "Could not verify saved test deposit Checkout Session before invoice void. "
+            "Could not verify saved deposit Checkout Session before invoice void. "
             "enquiry_id=%s invoice_id=%s session_id=%s",
             enquiry.pk,
             invoice.pk,
@@ -186,7 +196,7 @@ def _verify_expired_test_deposit_session(invoice):
     validation_errors = []
     if str(_stripe_value(session, "id", "") or "").strip() != session_id:
         validation_errors.append("Session ID")
-    if _stripe_value(session, "livemode") is not False:
+    if not _has_matching_checkout_environment(session, session_id):
         validation_errors.append("environment")
     if str(_stripe_value(session, "status", "") or "").lower() != "expired":
         validation_errors.append("status")
@@ -208,7 +218,7 @@ def _verify_expired_test_deposit_session(invoice):
     if validation_errors:
         raise ValidationError(
             "The saved Stripe Checkout Session is not an expired, unpaid, matching "
-            f"test deposit Session ({', '.join(validation_errors)})."
+            f"deposit Session ({', '.join(validation_errors)})."
         )
 
     try:
@@ -223,7 +233,7 @@ def _verify_expired_test_deposit_session(invoice):
         )
     except Exception as exc:
         logger.exception(
-            "Could not check for recovered test deposit Checkout Sessions before "
+            "Could not check for recovered deposit Checkout Sessions before "
             "invoice void. enquiry_id=%s invoice_id=%s session_id=%s",
             enquiry.pk,
             invoice.pk,
@@ -258,7 +268,7 @@ def void_local_realestate_invoice(invoice, *, user=None):
             or str(candidate.enquiry.deposit_payment_link or "").strip()
         )
     ):
-        verified_session_id = _verify_expired_test_deposit_session(candidate)
+        verified_session_id = _verify_expired_deposit_session(candidate)
 
     with transaction.atomic():
         invoice = (
@@ -341,7 +351,7 @@ def void_local_realestate_invoice(invoice, *, user=None):
         )
         if cleared_session_id:
             logger.info(
-                "Cleared verified expired unpaid test deposit Checkout Session before "
+                "Cleared verified expired unpaid deposit Checkout Session before "
                 "invoice void. enquiry_id=%s invoice_id=%s session_id=%s",
                 invoice.enquiry_id,
                 invoice.pk,

--- a/realestate/test_finance.py
+++ b/realestate/test_finance.py
@@ -173,6 +173,58 @@ class RealEstateFinanceTests(TestCase):
 
     @patch("realestate.finance.stripe.checkout.Session.list")
     @patch("realestate.finance.stripe.checkout.Session.retrieve")
+    def test_expired_unpaid_live_checkout_is_cleared_before_void(
+        self,
+        mock_retrieve,
+        mock_list,
+    ):
+        self.enquiry.stripe_deposit_session_id = "cs_live_existing"
+        self.enquiry.deposit_payment_link = "https://checkout.stripe.com/live"
+        self.enquiry.save(
+            update_fields=(
+                "stripe_deposit_session_id",
+                "deposit_payment_link",
+                "updated_at",
+            )
+        )
+        mock_retrieve.return_value = self._expired_test_deposit_session(
+            id="cs_live_existing",
+            livemode=True,
+        )
+        mock_list.return_value = self._stripe_session_list()
+
+        invoice, changed = void_local_realestate_invoice(
+            self.deposit,
+            user=self.staff,
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(invoice.status, RealEstateInvoice.Status.VOID)
+
+    @patch("realestate.finance.stripe.checkout.Session.retrieve")
+    def test_checkout_mode_and_session_identifier_mismatch_is_rejected(
+        self,
+        mock_retrieve,
+    ):
+        self.enquiry.stripe_deposit_session_id = "cs_live_existing"
+        self.enquiry.deposit_payment_link = "https://checkout.stripe.com/live"
+        self.enquiry.save(
+            update_fields=(
+                "stripe_deposit_session_id",
+                "deposit_payment_link",
+                "updated_at",
+            )
+        )
+        mock_retrieve.return_value = self._expired_test_deposit_session(
+            id="cs_live_existing",
+            livemode=False,
+        )
+
+        with self.assertRaisesMessage(ValidationError, "environment"):
+            void_local_realestate_invoice(self.deposit, user=self.staff)
+
+    @patch("realestate.finance.stripe.checkout.Session.list")
+    @patch("realestate.finance.stripe.checkout.Session.retrieve")
     def test_unsafe_or_mismatched_checkout_cannot_be_cleared_or_voided(
         self,
         mock_retrieve,
@@ -276,7 +328,7 @@ class RealEstateFinanceTests(TestCase):
         with self.assertRaisesMessage(ValidationError, "recovery-created"):
             void_local_realestate_invoice(self.deposit, user=self.staff)
 
-    @patch("realestate.finance._verify_expired_test_deposit_session")
+    @patch("realestate.finance._verify_expired_deposit_session")
     def test_checkout_reference_change_during_verification_fails_closed(
         self,
         mock_verify,

--- a/templates/admin/realestate/void_local_invoices.html
+++ b/templates/admin/realestate/void_local_invoices.html
@@ -4,7 +4,7 @@
   This marks the selected invoices as void while preserving their audit history.
   Only unpaid invoices without payment records or Stripe invoice references can be
   voided here. A saved deposit Checkout Session is cleared automatically only when
-  Stripe confirms that it is an expired, unpaid, matching test-mode Session with no
+  Stripe confirms that it is an expired, unpaid, matching Session with no
   recovery-created Session.
 </p>
 <p><strong>This does not delete the invoice or reuse its invoice number.</strong></p>


### PR DESCRIPTION
## Summary

Allows a safely verified expired, unpaid real-estate deposit Checkout Session to be cleared before voiding its local invoice whether Stripe created the Session in test or live mode.

## Why

Production test enquiries created live-mode Checkout Sessions. The void action required `livemode == false`, so otherwise safe expired and unpaid Sessions were rejected with an `environment` warning.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Verify that Stripe's explicit `livemode` value agrees with the `cs_test_` or `cs_live_` Session identifier.
  - Permit both environments only after all existing expired, unpaid, currency, metadata, recovery, payment-record, and concurrency checks pass.
  - Keep ambiguous or mismatched environment data fail-closed.
  - Update the admin confirmation copy to describe the corrected rule.
  - Add regressions for safe live-mode voiding and mode/identifier mismatch rejection.
- Frontend:
  - None.
- Infra/Config:
  - None; no migration required.

## Testing

- [x] Django tests pass locally — 462 tests
- [ ] React build passes locally — not applicable
- [ ] Manual smoke test done — requires deployed Stripe-backed admin
- `python manage.py check`
- `python manage.py makemigrations --check`
- `python manage.py test realestate`
- `python manage.py test`
- `git diff --check`

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (admin-only action unchanged)

## Risk & Rollback

Risk level: Medium

The change permits an expired unpaid live-mode Session to be cleared, but only after the same Stripe retrieval, metadata association, recovery scan, local payment checks, and locked concurrency recheck already required for test Sessions. Live/open/paid/recovered/mismatched or ambiguous Sessions remain blocked.

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described: revert this PR to restore the test-mode-only restriction.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (Stripe mode and Session identity must agree; uncertain state fails closed)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (shared environment helper and regression coverage)