### PR TITLE
fix(realestate): reconcile Stripe invoice revisions

### DIFF
--- a/checkout/views.py
+++ b/checkout/views.py
@@ -682,54 +682,99 @@ class StripeWebhookView(APIView):
     def _handle_realestate_invoice_event(self, event_type, stripe_invoice):
         from realestate.finance import record_realestate_payment
         from realestate.models import RealEstateInvoice, RealEstatePayment
+        from realestate.stripe_invoice_revisions import (
+            apply_revision_snapshot,
+            resolve_invoice_event,
+            stripe_datetime,
+            stripe_reference_id,
+            stripe_value,
+            was_manually_voided,
+        )
 
         metadata = stripe_invoice.get('metadata') or {}
         number = str(metadata.get('realestate_invoice_number') or '').strip()
         stripe_id = str(stripe_invoice.get('id') or '').strip()
-        invoice = RealEstateInvoice.objects.select_for_update().filter(
-            Q(invoice_number=number) | Q(stripe_invoice_id=stripe_id)
-        ).select_related('enquiry').first()
+        locked_invoices = RealEstateInvoice.objects.select_for_update().select_related('enquiry')
+        invoice_by_number = locked_invoices.filter(invoice_number=number).first() if number else None
+        invoice_by_stripe_id = (
+            locked_invoices.filter(stripe_invoice_id=stripe_id).first()
+            if stripe_id
+            else None
+        )
+        if (
+            invoice_by_number is not None
+            and invoice_by_stripe_id is not None
+            and invoice_by_number.pk != invoice_by_stripe_id.pk
+        ):
+            raise RuntimeError(
+                'Stripe invoice metadata and external ID identified different local invoices.'
+            )
+        invoice = invoice_by_number or invoice_by_stripe_id
         if invoice is None:
             return False
-        if stripe_id and invoice.stripe_invoice_id and stripe_id != invoice.stripe_invoice_id:
-            raise RuntimeError('Stripe invoice did not match the stored local invoice.')
 
-        stripe_status = str(stripe_invoice.get('status') or event_type.split('.', 1)[1])
-        fields = ['stripe_invoice_status', 'updated_at']
-        invoice.stripe_invoice_status = stripe_status
-        for source, target in (
-            ('number', 'stripe_invoice_number'), ('hosted_invoice_url', 'stripe_hosted_invoice_url'),
-            ('invoice_pdf', 'stripe_invoice_pdf_url'),
-        ):
-            value = str(stripe_invoice.get(source) or '')
-            if value:
-                setattr(invoice, target, value)
-                fields.append(target)
+        resolution = resolve_invoice_event(invoice, stripe_invoice)
+        current = resolution.current
+        current_id = stripe_reference_id(current)
+        apply_revision_snapshot(invoice, current)
+
+        # A delayed event for a superseded ancestor must never roll the local
+        # invoice back or apply the ancestor's terminal state.
+        if stripe_id != current_id:
+            logger.info(
+                "Ignoring superseded real estate Stripe invoice event. "
+                "invoice_id=%s enquiry_id=%s event_stripe_invoice_id=%s "
+                "current_stripe_invoice_id=%s event_type=%s",
+                invoice.pk,
+                invoice.enquiry_id,
+                stripe_id,
+                current_id,
+                event_type,
+            )
+            return True
 
         if event_type == 'invoice.paid':
-            currency = str(stripe_invoice.get('currency') or '').upper()
-            amount_paid = int(stripe_invoice.get('amount_paid') or 0)
+            currency = str(stripe_value(current, 'currency', '') or '').upper()
+            amount_paid = int(stripe_value(current, 'amount_paid', 0) or 0)
             expected = int(invoice.total * Decimal('100'))
             if currency != invoice.currency or amount_paid != expected:
                 raise RuntimeError('Stripe invoice paid amount or currency did not match the local invoice.')
+            if invoice.status == RealEstateInvoice.Status.VOID:
+                if (
+                    was_manually_voided(invoice)
+                    or invoice.payments.filter(status=RealEstatePayment.Status.SUCCEEDED).exists()
+                ):
+                    raise RuntimeError(
+                        'A manually or independently voided local invoice cannot be reopened.'
+                    )
+                invoice.status = RealEstateInvoice.Status.ISSUED
+                invoice.save(update_fields=('status', 'updated_at'))
+            if invoice.amount_outstanding not in {Decimal('0.00'), invoice.total}:
+                raise RuntimeError(
+                    'Stripe reported the full invoice paid but the local invoice has a partial payment.'
+                )
             if invoice.amount_outstanding:
+                transitions = stripe_value(current, 'status_transitions', {}) or {}
                 record_realestate_payment(
                     invoice=invoice, amount=invoice.amount_outstanding,
                     method=RealEstatePayment.Method.STRIPE_INVOICE,
-                    paid_at=timezone.now(), stripe_payment_intent_id=str(stripe_invoice.get('payment_intent') or ''),
-                    stripe_charge_id=str(stripe_invoice.get('charge') or ''),
-                    external_reference=stripe_id,
+                    paid_at=(stripe_datetime(stripe_value(transitions, 'paid_at')) or timezone.now()),
+                    stripe_payment_intent_id=str(stripe_value(current, 'payment_intent', '') or ''),
+                    stripe_charge_id=str(stripe_value(current, 'charge', '') or ''),
+                    external_reference=current_id,
                     notes='Reconciled from Stripe invoice.paid webhook.',
                 )
             invoice.stripe_invoice_status = 'paid'
         elif event_type == 'invoice.voided':
             if not invoice.amount_paid:
                 invoice.status = RealEstateInvoice.Status.VOID
-                fields.append('status')
+                invoice.save(update_fields=('status', 'updated_at'))
         elif event_type == 'invoice.marked_uncollectible':
             invoice.status = RealEstateInvoice.Status.OVERDUE
-            fields.append('status')
-        invoice.save(update_fields=tuple(dict.fromkeys(fields)))
+            invoice.save(update_fields=('status', 'updated_at'))
+        if invoice.stripe_invoice_status != str(stripe_value(current, 'status', '') or ''):
+            invoice.stripe_invoice_status = str(stripe_value(current, 'status', '') or '')
+        invoice.save(update_fields=('stripe_invoice_status', 'updated_at'))
         return True
 
     def _stale_processing_seconds(self):

--- a/realestate/management/commands/reconcile_realestate_stripe_invoice_revisions.py
+++ b/realestate/management/commands/reconcile_realestate_stripe_invoice_revisions.py
@@ -1,0 +1,100 @@
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from realestate.models import RealEstateInvoice, RealEstatePayment
+from realestate.stripe_invoice_revisions import (
+    StripeInvoiceRevisionError,
+    apply_revision_snapshot,
+    inspect_stored_invoice_revision,
+    stripe_reference_id,
+    stripe_value,
+    was_manually_voided,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Safely inspect or apply Stripe Invoice revisions to a real-estate invoice."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--invoice-number", required=True)
+        mode = parser.add_mutually_exclusive_group()
+        mode.add_argument("--dry-run", action="store_true")
+        mode.add_argument("--apply", action="store_true")
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        invoice_number = str(options["invoice_number"] or "").strip()
+        try:
+            invoice = (
+                RealEstateInvoice.objects.select_for_update()
+                .select_related("enquiry")
+                .get(invoice_number=invoice_number)
+            )
+        except RealEstateInvoice.DoesNotExist as exc:
+            raise CommandError(f"Local invoice {invoice_number} was not found.") from exc
+
+        stored_id = str(invoice.stripe_invoice_id or "").strip()
+        stored_status = str(invoice.stripe_invoice_status or "").strip() or "unknown"
+        try:
+            chain = inspect_stored_invoice_revision(invoice)
+        except StripeInvoiceRevisionError as exc:
+            raise CommandError(str(exc)) from exc
+        current = chain[-1]
+        current_id = stripe_reference_id(current)
+        current_status = str(stripe_value(current, "status", "") or "").strip() or "unknown"
+
+        self.stdout.write(f"local_invoice_status={invoice.status}")
+        self.stdout.write(f"stored_stripe_invoice_status={stored_status}")
+        self.stdout.write(f"stored_stripe_invoice_id={stored_id or 'missing'}")
+        self.stdout.write(f"current_stripe_invoice_id={current_id}")
+        self.stdout.write(f"current_stripe_invoice_status={current_status}")
+        self.stdout.write("revision_chain=" + " -> ".join(stripe_reference_id(item) for item in chain))
+
+        successful_total = sum(
+            invoice.payments.filter(status=RealEstatePayment.Status.SUCCEEDED)
+            .values_list("amount", flat=True),
+            start=invoice.total * 0,
+        )
+        if current_status == "paid" and successful_total != invoice.total:
+            raise CommandError(
+                "Stripe reports the current revision paid but the local successful "
+                "payment total does not match; reconcile payment separately."
+            )
+        if invoice.status == RealEstateInvoice.Status.PAID and current_status != "paid":
+            raise CommandError(
+                "The local invoice is paid but the current Stripe revision is not paid."
+            )
+        if invoice.status == RealEstateInvoice.Status.VOID and was_manually_voided(invoice):
+            raise CommandError("A manually voided local invoice will not be reopened.")
+        if current_status == "open" and successful_total:
+            raise CommandError(
+                "The current Stripe revision is open but local successful payments exist."
+            )
+
+        if not options["apply"]:
+            self.stdout.write(self.style.WARNING("DRY RUN: no local records were changed."))
+            return
+
+        changed, revision_changed, restored = apply_revision_snapshot(invoice, current)
+        logger.info(
+            "Applied real estate Stripe invoice revision reconciliation. "
+            "invoice_id=%s enquiry_id=%s old_stripe_invoice_id=%s "
+            "new_stripe_invoice_id=%s changed=%s restored=%s",
+            invoice.pk,
+            invoice.enquiry_id,
+            stored_id,
+            current_id,
+            changed,
+            restored,
+        )
+        if revision_changed:
+            self.stdout.write(self.style.SUCCESS("Applied the verified Stripe invoice revision."))
+        elif changed:
+            self.stdout.write(self.style.SUCCESS("Refreshed the current Stripe invoice fields."))
+        else:
+            self.stdout.write("No changes were required; the local invoice is already current.")

--- a/realestate/stripe_invoice_revisions.py
+++ b/realestate/stripe_invoice_revisions.py
@@ -1,0 +1,357 @@
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone as dt_timezone
+from decimal import Decimal
+
+import stripe
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+
+from .models import RealEstateInvoice, RealEstatePayment, RealEstateTimelineEvent
+from .timeline import record_timeline_event
+
+
+logger = logging.getLogger(__name__)
+MAX_REVISION_DEPTH = 8
+
+
+class StripeInvoiceRevisionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class RevisionResolution:
+    current: object
+    relation: str
+    chain_ids: tuple[str, ...]
+
+
+def stripe_value(obj, key, default=None):
+    if hasattr(obj, "get"):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def stripe_reference_id(value):
+    if isinstance(value, str):
+        return value.strip()
+    return str(stripe_value(value, "id", "") or "").strip()
+
+
+def configure_stripe():
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+    stripe.max_network_retries = getattr(settings, "STRIPE_MAX_NETWORK_RETRIES", 2)
+
+
+def configured_stripe_livemode():
+    key = str(getattr(settings, "STRIPE_SECRET_KEY", "") or "").strip()
+    if key.startswith(("sk_live_", "rk_live_")):
+        return True
+    if key.startswith(("sk_test_", "rk_test_")):
+        return False
+    raise StripeInvoiceRevisionError(
+        "The configured Stripe key does not identify a test or live environment."
+    )
+
+
+def _integer_value(obj, key):
+    value = stripe_value(obj, key)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise StripeInvoiceRevisionError(
+            f"Stripe invoice has an invalid {key}."
+        ) from None
+
+
+def validate_stripe_invoice(local_invoice, stripe_invoice):
+    stripe_id = stripe_reference_id(stripe_invoice)
+    if not stripe_id.startswith("in_"):
+        raise StripeInvoiceRevisionError("Stripe invoice has an invalid invoice ID.")
+
+    metadata = stripe_value(stripe_invoice, "metadata", {}) or {}
+    expected = {
+        "realestate_invoice_number": local_invoice.invoice_number,
+        "realestate_enquiry_id": str(local_invoice.enquiry_id),
+        "payment_purpose": f"realestate_{local_invoice.invoice_type}",
+    }
+    for key, expected_value in expected.items():
+        if str(metadata.get(key) or "").strip() != expected_value:
+            raise StripeInvoiceRevisionError(
+                f"Stripe invoice {key} did not match the local invoice."
+            )
+
+    currency = str(stripe_value(stripe_invoice, "currency", "") or "").upper()
+    if currency != local_invoice.currency:
+        raise StripeInvoiceRevisionError(
+            "Stripe invoice currency did not match the local invoice."
+        )
+    expected_total = int(Decimal(local_invoice.total) * Decimal("100"))
+    if _integer_value(stripe_invoice, "total") != expected_total:
+        raise StripeInvoiceRevisionError(
+            "Stripe invoice total did not match the local invoice."
+        )
+    amount_due = _integer_value(stripe_invoice, "amount_due")
+    stripe_status = str(stripe_value(stripe_invoice, "status", "") or "").lower()
+    permitted_amounts_due = {expected_total}
+    if stripe_status == "void":
+        permitted_amounts_due.add(0)
+    if amount_due not in permitted_amounts_due:
+        raise StripeInvoiceRevisionError(
+            "Stripe invoice amount due did not match the local invoice."
+        )
+    livemode = stripe_value(stripe_invoice, "livemode")
+    if not isinstance(livemode, bool) or livemode != configured_stripe_livemode():
+        raise StripeInvoiceRevisionError(
+            "Stripe invoice environment did not match the configured environment."
+        )
+    return stripe_id
+
+
+def _retrieve_invoice(stripe_id):
+    if not stripe_id.startswith("in_"):
+        raise StripeInvoiceRevisionError("Stripe revision contains an invalid invoice ID.")
+    return stripe.Invoice.retrieve(stripe_id)
+
+
+def _load_reference(value):
+    stripe_id = stripe_reference_id(value)
+    if not stripe_id:
+        raise StripeInvoiceRevisionError("Stripe revision contains a missing invoice reference.")
+    if isinstance(value, str):
+        return _retrieve_invoice(stripe_id)
+    return value
+
+
+def _from_invoice(stripe_invoice):
+    from_invoice = stripe_value(stripe_invoice, "from_invoice", {}) or {}
+    return (
+        str(stripe_value(from_invoice, "action", "") or "").strip(),
+        stripe_value(from_invoice, "invoice"),
+    )
+
+
+def _assert_revision_parent(local_invoice, parent, child):
+    parent_id = validate_stripe_invoice(local_invoice, parent)
+    validate_stripe_invoice(local_invoice, child)
+    action, parent_reference = _from_invoice(child)
+    if action != "revision" or stripe_reference_id(parent_reference) != parent_id:
+        raise StripeInvoiceRevisionError(
+            "Stripe invoice did not identify the expected revision parent."
+        )
+
+
+def _backward_chain_to_id(local_invoice, child, target_id, *, max_depth):
+    child_id = validate_stripe_invoice(local_invoice, child)
+    visited = {child_id}
+    reverse_chain = [child]
+    for _ in range(max_depth):
+        action, parent_reference = _from_invoice(child)
+        parent_id = stripe_reference_id(parent_reference)
+        if action != "revision" or not parent_id:
+            return None
+        if parent_id in visited:
+            raise StripeInvoiceRevisionError("Stripe invoice revision chain contains a cycle.")
+        parent = _load_reference(parent_reference)
+        _assert_revision_parent(local_invoice, parent, child)
+        reverse_chain.append(parent)
+        visited.add(parent_id)
+        if parent_id == target_id:
+            return list(reversed(reverse_chain))
+        child = parent
+    raise StripeInvoiceRevisionError(
+        f"Stripe invoice revision chain exceeds {max_depth} revisions."
+    )
+
+
+def follow_latest_revisions(local_invoice, start, *, max_depth=MAX_REVISION_DEPTH):
+    current = start
+    current_id = validate_stripe_invoice(local_invoice, current)
+    chain = [current]
+    visited = {current_id}
+    traversed = 0
+    while traversed < max_depth:
+        latest_reference = stripe_value(current, "latest_revision")
+        latest_id = stripe_reference_id(latest_reference)
+        if not latest_id:
+            return chain
+        if latest_id in visited:
+            raise StripeInvoiceRevisionError("Stripe invoice revision chain contains a cycle.")
+        latest = _load_reference(latest_reference)
+        segment = _backward_chain_to_id(
+            local_invoice,
+            latest,
+            current_id,
+            max_depth=max_depth - traversed,
+        )
+        if not segment:
+            raise StripeInvoiceRevisionError(
+                "Stripe latest revision was not descended from the expected invoice."
+            )
+        for revision in segment[1:]:
+            revision_id = validate_stripe_invoice(local_invoice, revision)
+            if revision_id in visited:
+                raise StripeInvoiceRevisionError(
+                    "Stripe invoice revision chain contains a cycle."
+                )
+            chain.append(revision)
+            visited.add(revision_id)
+            traversed += 1
+            if traversed > max_depth:
+                raise StripeInvoiceRevisionError(
+                    f"Stripe invoice revision chain exceeds {max_depth} revisions."
+                )
+        current = latest
+        current_id = latest_id
+    if stripe_reference_id(stripe_value(current, "latest_revision")):
+        raise StripeInvoiceRevisionError(
+            f"Stripe invoice revision chain exceeds {max_depth} revisions."
+        )
+    return chain
+
+
+def _backward_chain_to_stored(local_invoice, incoming, stored_id):
+    return _backward_chain_to_id(
+        local_invoice,
+        incoming,
+        stored_id,
+        max_depth=MAX_REVISION_DEPTH,
+    )
+
+
+def resolve_invoice_event(local_invoice, incoming):
+    stored_id = str(local_invoice.stripe_invoice_id or "").strip()
+    if not stored_id:
+        raise StripeInvoiceRevisionError(
+            "The local invoice has no stored Stripe invoice to anchor a revision."
+        )
+    incoming_id = validate_stripe_invoice(local_invoice, incoming)
+
+    if incoming_id == stored_id:
+        forward = follow_latest_revisions(local_invoice, incoming)
+        relation = "descendant" if len(forward) > 1 else "same"
+        return RevisionResolution(
+            current=forward[-1],
+            relation=relation,
+            chain_ids=tuple(validate_stripe_invoice(local_invoice, item) for item in forward),
+        )
+
+    backward = _backward_chain_to_stored(local_invoice, incoming, stored_id)
+    if backward:
+        forward_from_incoming = follow_latest_revisions(local_invoice, incoming)
+        combined = backward[:-1] + forward_from_incoming
+        return RevisionResolution(
+            current=combined[-1],
+            relation="descendant",
+            chain_ids=tuple(validate_stripe_invoice(local_invoice, item) for item in combined),
+        )
+
+    forward = follow_latest_revisions(local_invoice, incoming)
+    forward_ids = [validate_stripe_invoice(local_invoice, item) for item in forward]
+    if stored_id in forward_ids:
+        return RevisionResolution(
+            current=forward[-1],
+            relation="ancestor",
+            chain_ids=tuple(forward_ids),
+        )
+    raise StripeInvoiceRevisionError(
+        "Stripe invoice was unrelated to the stored local Stripe invoice."
+    )
+
+
+def stripe_datetime(timestamp):
+    try:
+        timestamp = int(timestamp)
+    except (TypeError, ValueError):
+        return None
+    return datetime.fromtimestamp(timestamp, tz=dt_timezone.utc) if timestamp else None
+
+
+def was_manually_voided(local_invoice):
+    return local_invoice.enquiry.timeline_events.filter(
+        title="Invoice voided",
+        notes__contains=local_invoice.invoice_number,
+    ).exists()
+
+
+def apply_revision_snapshot(local_invoice, stripe_invoice, *, record_audit=True):
+    new_id = validate_stripe_invoice(local_invoice, stripe_invoice)
+    old_id = str(local_invoice.stripe_invoice_id or "").strip()
+    old_status = str(local_invoice.stripe_invoice_status or "").strip()
+    fields = []
+    values = {
+        "stripe_invoice_id": new_id,
+        "stripe_invoice_number": str(stripe_value(stripe_invoice, "number", "") or ""),
+        "stripe_hosted_invoice_url": str(
+            stripe_value(stripe_invoice, "hosted_invoice_url", "") or ""
+        ),
+        "stripe_invoice_pdf_url": str(stripe_value(stripe_invoice, "invoice_pdf", "") or ""),
+        "stripe_invoice_status": str(stripe_value(stripe_invoice, "status", "") or ""),
+    }
+    created_at = stripe_datetime(stripe_value(stripe_invoice, "created"))
+    if created_at:
+        values["stripe_invoice_created_at"] = created_at
+    transitions = stripe_value(stripe_invoice, "status_transitions", {}) or {}
+    finalized_at = stripe_datetime(stripe_value(transitions, "finalized_at"))
+    if finalized_at:
+        values["stripe_invoice_finalized_at"] = finalized_at
+    for field, value in values.items():
+        if getattr(local_invoice, field) != value:
+            setattr(local_invoice, field, value)
+            fields.append(field)
+
+    restored = False
+    if (
+        values["stripe_invoice_status"] == "open"
+        and local_invoice.status == RealEstateInvoice.Status.VOID
+        and not local_invoice.payments.filter(status=RealEstatePayment.Status.SUCCEEDED).exists()
+        and not was_manually_voided(local_invoice)
+    ):
+        local_invoice.status = RealEstateInvoice.Status.ISSUED
+        fields.append("status")
+        restored = True
+
+    if fields:
+        local_invoice.save(update_fields=tuple(dict.fromkeys(fields + ["updated_at"])))
+    revision_changed = bool(old_id and old_id != new_id)
+    if record_audit and (revision_changed or restored):
+        record_timeline_event(
+            local_invoice.enquiry,
+            RealEstateTimelineEvent.EventType.NOTE,
+            title="Stripe invoice revision reconciled",
+            notes=(
+                f"Stripe invoice {old_id or 'missing'} ({old_status or 'unknown'}) was "
+                f"superseded by {new_id} ({values['stripe_invoice_status'] or 'unknown'})."
+            ),
+        )
+        logger.info(
+            "Reconciled real estate Stripe invoice revision. invoice_id=%s "
+            "enquiry_id=%s old_stripe_invoice_id=%s new_stripe_invoice_id=%s",
+            local_invoice.pk,
+            local_invoice.enquiry_id,
+            old_id or "missing",
+            new_id,
+        )
+    return bool(fields), revision_changed, restored
+
+
+@transaction.atomic
+def reconcile_stored_invoice_revision(local_invoice, *, record_audit=True):
+    local_invoice = (
+        RealEstateInvoice.objects.select_for_update()
+        .select_related("enquiry")
+        .get(pk=local_invoice.pk)
+    )
+    chain = inspect_stored_invoice_revision(local_invoice)
+    apply_revision_snapshot(local_invoice, chain[-1], record_audit=record_audit)
+    return local_invoice, chain
+
+
+def inspect_stored_invoice_revision(local_invoice):
+    configure_stripe()
+    stored_id = str(local_invoice.stripe_invoice_id or "").strip()
+    if not stored_id:
+        raise StripeInvoiceRevisionError("The local invoice has no stored Stripe invoice.")
+    stored = _retrieve_invoice(stored_id)
+    return follow_latest_revisions(local_invoice, stored)

--- a/realestate/stripe_invoices.py
+++ b/realestate/stripe_invoices.py
@@ -10,6 +10,10 @@ from django.utils import timezone
 from openeire_api.business_identity import get_business_identity
 
 from .models import RealEstateInvoice
+from .stripe_invoice_revisions import (
+    StripeInvoiceRevisionError,
+    reconcile_stored_invoice_revision,
+)
 
 
 def _value(obj, key, default=""):
@@ -114,10 +118,15 @@ def create_stripe_invoice(local_invoice, *, send=False):
     return local_invoice, True
 
 
+@transaction.atomic
 def send_stripe_invoice(local_invoice):
     if not local_invoice.stripe_invoice_id:
         return create_stripe_invoice(local_invoice, send=True)[0]
-    _configure_stripe()
+    local_invoice, _chain = reconcile_stored_invoice_revision(local_invoice)
+    if local_invoice.stripe_invoice_status in {"void", "paid", "uncollectible"}:
+        raise ValidationError(
+            "The current Stripe invoice cannot be sent in its present status."
+        )
     result = stripe.Invoice.send_invoice(local_invoice.stripe_invoice_id)
     local_invoice.stripe_invoice_status = str(_value(result, "status", "open"))
     local_invoice.save(update_fields=("stripe_invoice_status", "updated_at"))
@@ -131,6 +140,10 @@ def mark_stripe_invoice_paid_out_of_band(local_invoice, *, user):
     local_invoice = RealEstateInvoice.objects.select_for_update().get(pk=local_invoice.pk)
     if not local_invoice.stripe_invoice_id:
         raise ValidationError("This invoice has no Stripe invoice.")
+    try:
+        local_invoice, _chain = reconcile_stored_invoice_revision(local_invoice)
+    except StripeInvoiceRevisionError as exc:
+        raise ValidationError(str(exc)) from exc
     if local_invoice.amount_outstanding:
         raise ValidationError("Record the successful local payment before marking Stripe paid.")
     if local_invoice.stripe_marked_paid_out_of_band_at:

--- a/realestate/test_finance.py
+++ b/realestate/test_finance.py
@@ -1,12 +1,12 @@
 from decimal import Decimal
-from io import BytesIO
+from io import BytesIO, StringIO
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.core.exceptions import PermissionDenied, ValidationError
-from django.core.management import call_command
+from django.core.management import call_command, CommandError
 from django.test import RequestFactory, TestCase, TransactionTestCase, override_settings
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
@@ -26,7 +26,12 @@ from .finance import (
     revoke_delivery_override,
     void_local_realestate_invoice,
 )
-from .stripe_invoices import create_stripe_invoice, mark_stripe_invoice_paid_out_of_band
+from .stripe_invoices import (
+    create_stripe_invoice,
+    mark_stripe_invoice_paid_out_of_band,
+    send_stripe_invoice,
+)
+from .stripe_invoice_revisions import StripeInvoiceRevisionError
 from .admin import RealEstateEnquiryAdmin, RealEstateInvoiceAdmin
 from openeire_api.admin import custom_admin_site
 from .financial_documents import (
@@ -703,6 +708,7 @@ class RealEstateLedgerMigrationTests(TransactionTestCase):
         super().tearDown()
 
 
+@override_settings(STRIPE_SECRET_KEY="sk_test_realestate_invoices")
 class FullPaymentArrangementTests(TestCase):
     def make_enquiry(self, arrangement, **overrides):
         values = {
@@ -717,6 +723,30 @@ class FullPaymentArrangementTests(TestCase):
         enquiry = RealEstateEnquiry.objects.create(**values)
         calculate_realestate_deposit_amounts(enquiry)
         return enquiry
+
+    def stripe_invoice_payload(self, invoice, stripe_id, *, status="open", **overrides):
+        values = {
+            "id": stripe_id,
+            "number": f"STRIPE-{stripe_id}",
+            "status": status,
+            "currency": invoice.currency.lower(),
+            "total": int(invoice.total * Decimal("100")),
+            "amount_due": int(invoice.total * Decimal("100")),
+            "livemode": False,
+            "created": int(timezone.now().timestamp()),
+            "status_transitions": {"finalized_at": int(timezone.now().timestamp())},
+            "hosted_invoice_url": f"https://invoice.stripe.test/{stripe_id}",
+            "invoice_pdf": f"https://invoice.stripe.test/{stripe_id}.pdf",
+            "metadata": {
+                "realestate_invoice_number": invoice.invoice_number,
+                "realestate_enquiry_id": str(invoice.enquiry_id),
+                "payment_purpose": f"realestate_{invoice.invoice_type}",
+            },
+            "latest_revision": None,
+            "from_invoice": None,
+        }
+        values.update(overrides)
+        return values
 
     def test_full_upfront_creates_one_full_invoice(self):
         enquiry = self.make_enquiry(RealEstateEnquiry.PaymentArrangement.FULL_UPFRONT)
@@ -789,7 +819,8 @@ class FullPaymentArrangementTests(TestCase):
         self.assertEqual(invoice_create.call_count, 1)
 
     @patch("realestate.stripe_invoices.stripe.Invoice.pay")
-    def test_out_of_band_cash_settlement_and_paid_webhook_do_not_duplicate(self, pay):
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_out_of_band_cash_settlement_and_paid_webhook_do_not_duplicate(self, retrieve, pay):
         enquiry = self.make_enquiry(RealEstateEnquiry.PaymentArrangement.FULL_ON_SHOOT_DAY)
         invoice = ensure_invoices_for_arrangement(enquiry)[0]
         invoice.stripe_invoice_id = "in_cash"
@@ -800,12 +831,12 @@ class FullPaymentArrangementTests(TestCase):
             paid_at=timezone.now(), recorded_by=staff, external_reference="Kevin", notes="cash",
         )
         invoice.refresh_from_db()
+        retrieve.return_value = self.stripe_invoice_payload(invoice, "in_cash")
         mark_stripe_invoice_paid_out_of_band(invoice, user=staff)
         pay.assert_called_once_with("in_cash", paid_out_of_band=True)
-        payload = {
-            "id": "in_cash", "status": "paid", "currency": "eur", "amount_paid": 39900,
-            "metadata": {"realestate_invoice_number": invoice.invoice_number},
-        }
+        payload = self.stripe_invoice_payload(
+            invoice, "in_cash", status="paid", amount_paid=39900
+        )
         self.assertTrue(StripeWebhookView()._handle_realestate_invoice_event("invoice.paid", payload))
         self.assertEqual(RealEstatePayment.objects.count(), 1)
 
@@ -814,11 +845,10 @@ class FullPaymentArrangementTests(TestCase):
         invoice = ensure_invoices_for_arrangement(enquiry)[0]
         invoice.stripe_invoice_id = "in_card"
         invoice.save(update_fields=("stripe_invoice_id", "updated_at"))
-        payload = {
-            "id": "in_card", "status": "paid", "currency": "eur", "amount_paid": 39900,
-            "payment_intent": "pi_card", "charge": "ch_card",
-            "metadata": {"realestate_invoice_number": invoice.invoice_number},
-        }
+        payload = self.stripe_invoice_payload(
+            invoice, "in_card", status="paid", amount_paid=39900,
+            payment_intent="pi_card", charge="ch_card",
+        )
         self.assertTrue(StripeWebhookView()._handle_realestate_invoice_event("invoice.paid", payload))
         payment = RealEstatePayment.objects.get()
         self.assertEqual(payment.method, RealEstatePayment.Method.STRIPE_INVOICE)
@@ -831,7 +861,7 @@ class FullPaymentArrangementTests(TestCase):
         invoice.stripe_invoice_id = "in_state"
         invoice.save(update_fields=("stripe_invoice_id", "updated_at"))
         view = StripeWebhookView()
-        base = {"id": "in_state", "currency": "eur", "metadata": {"realestate_invoice_number": invoice.invoice_number}}
+        base = self.stripe_invoice_payload(invoice, "in_state")
         self.assertTrue(view._handle_realestate_invoice_event("invoice.payment_failed", {**base, "status": "open"}))
         invoice.refresh_from_db()
         self.assertEqual(invoice.stripe_invoice_status, "open")
@@ -841,6 +871,430 @@ class FullPaymentArrangementTests(TestCase):
         summary = str(RealEstateEnquiryAdmin(RealEstateEnquiry, custom_admin_site).financial_summary(enquiry))
         self.assertIn("EUR 399.00", summary)
         self.assertIn("Locked", summary)
+
+
+@override_settings(STRIPE_SECRET_KEY="sk_test_revision_tests")
+class StripeInvoiceRevisionTests(TestCase):
+    def setUp(self):
+        self.enquiry = RealEstateEnquiry.objects.create(
+            name="Revision Client",
+            email="revision@example.com",
+            phone="123",
+            client_type=RealEstateEnquiry.ClientType.PRIVATE_SELLER,
+            property_address="Revision House",
+            county="Galway",
+            property_type="House",
+            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            consent_to_contact=True,
+            quoted_price=Decimal("399.00"),
+            payment_arrangement=RealEstateEnquiry.PaymentArrangement.FULL_UPFRONT,
+        )
+        calculate_realestate_deposit_amounts(self.enquiry)
+        self.invoice = ensure_invoices_for_arrangement(self.enquiry)[0]
+        self.invoice.stripe_invoice_id = "in_original"
+        self.invoice.stripe_invoice_number = "STRIPE-OLD"
+        self.invoice.stripe_invoice_status = "open"
+        self.invoice.save(update_fields=(
+            "stripe_invoice_id",
+            "stripe_invoice_number",
+            "stripe_invoice_status",
+            "updated_at",
+        ))
+        self.view = StripeWebhookView()
+
+    def payload(self, stripe_id, *, status="open", **overrides):
+        now = int(timezone.now().timestamp())
+        values = {
+            "id": stripe_id,
+            "number": f"STRIPE-{stripe_id}",
+            "status": status,
+            "currency": "eur",
+            "total": 39900,
+            "amount_due": 39900,
+            "amount_paid": 0,
+            "livemode": False,
+            "created": now,
+            "status_transitions": {"finalized_at": now},
+            "hosted_invoice_url": f"https://invoice.stripe.test/{stripe_id}",
+            "invoice_pdf": f"https://invoice.stripe.test/{stripe_id}.pdf",
+            "metadata": {
+                "realestate_invoice_number": self.invoice.invoice_number,
+                "realestate_enquiry_id": str(self.enquiry.pk),
+                "payment_purpose": "realestate_full",
+            },
+            "latest_revision": None,
+            "from_invoice": None,
+        }
+        values.update(overrides)
+        return values
+
+    def revision_pair(self, *, child_id="in_revision", child_status="open"):
+        parent = self.payload(
+            "in_original", status="void", latest_revision=child_id
+        )
+        child = self.payload(
+            child_id,
+            status=child_status,
+            from_invoice={"action": "revision", "invoice": "in_original"},
+        )
+        return parent, child
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_valid_direct_revision_updates_all_external_fields(self, retrieve):
+        parent, child = self.revision_pair()
+        retrieve.return_value = parent
+
+        self.assertTrue(self.view._handle_realestate_invoice_event("invoice.finalized", child))
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.ISSUED)
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_revision")
+        self.assertEqual(self.invoice.stripe_invoice_number, "STRIPE-in_revision")
+        self.assertEqual(
+            self.invoice.stripe_hosted_invoice_url,
+            "https://invoice.stripe.test/in_revision",
+        )
+        self.assertEqual(
+            self.invoice.stripe_invoice_pdf_url,
+            "https://invoice.stripe.test/in_revision.pdf",
+        )
+        self.assertEqual(self.invoice.stripe_invoice_status, "open")
+        self.assertIsNotNone(self.invoice.stripe_invoice_created_at)
+        self.assertIsNotNone(self.invoice.stripe_invoice_finalized_at)
+        self.assertEqual(
+            self.enquiry.timeline_events.filter(
+                title="Stripe invoice revision reconciled"
+            ).count(),
+            1,
+        )
+
+    @override_settings(STRIPE_SECRET_KEY="sk_live_revision_tests")
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_valid_live_mode_revision_is_accepted(self, retrieve):
+        parent, child = self.revision_pair()
+        parent["livemode"] = True
+        child["livemode"] = True
+        retrieve.return_value = parent
+
+        self.view._handle_realestate_invoice_event("invoice.finalized", child)
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_revision")
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_multi_step_revision_chain_is_accepted(self, retrieve):
+        original = self.payload("in_original", status="void", latest_revision="in_revision_1")
+        revision_1 = self.payload(
+            "in_revision_1",
+            status="void",
+            latest_revision="in_revision_2",
+            from_invoice={"action": "revision", "invoice": "in_original"},
+        )
+        revision_2 = self.payload(
+            "in_revision_2",
+            from_invoice={"action": "revision", "invoice": "in_revision_1"},
+        )
+        retrieve.side_effect = lambda stripe_id: {
+            "in_original": original,
+            "in_revision_1": revision_1,
+        }[stripe_id]
+
+        self.view._handle_realestate_invoice_event("invoice.finalized", revision_2)
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_revision_2")
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_original_void_before_revised_finalized_does_not_void_local(self, retrieve):
+        parent, child = self.revision_pair()
+        retrieve.side_effect = lambda stripe_id: child if stripe_id == "in_revision" else parent
+
+        self.view._handle_realestate_invoice_event("invoice.voided", parent)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.ISSUED)
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_revision")
+
+        self.view._handle_realestate_invoice_event("invoice.finalized", child)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.ISSUED)
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_revised_finalized_before_delayed_original_void_is_safe(self, retrieve):
+        parent, child = self.revision_pair()
+        retrieve.side_effect = lambda stripe_id: parent if stripe_id == "in_original" else child
+        self.view._handle_realestate_invoice_event("invoice.finalized", child)
+
+        self.view._handle_realestate_invoice_event("invoice.voided", parent)
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.ISSUED)
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_revision")
+        self.assertEqual(self.invoice.stripe_invoice_status, "open")
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_revised_sent_event_updates_current_revision(self, retrieve):
+        parent, child = self.revision_pair()
+        retrieve.return_value = parent
+
+        self.view._handle_realestate_invoice_event("invoice.sent", child)
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_revision")
+        self.assertEqual(self.invoice.stripe_invoice_status, "open")
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_revised_paid_event_is_idempotent(self, retrieve):
+        parent, child = self.revision_pair(child_status="paid")
+        child.update(amount_paid=39900, payment_intent="pi_revision", charge="ch_revision")
+        retrieve.return_value = parent
+
+        self.view._handle_realestate_invoice_event("invoice.paid", child)
+        self.view._handle_realestate_invoice_event("invoice.paid", child)
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.PAID)
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_revision")
+        self.assertEqual(self.invoice.payments.filter(status="succeeded").count(), 1)
+        payment = self.invoice.payments.get(status="succeeded")
+        self.assertEqual(payment.external_reference, "in_revision")
+
+    @patch("realestate.stripe_invoices.stripe.Invoice.send_invoice")
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_reminder_reconciles_and_sends_current_revision(self, retrieve, send):
+        parent, child = self.revision_pair()
+        retrieve.side_effect = lambda stripe_id: {
+            "in_original": parent,
+            "in_revision": child,
+        }[stripe_id]
+        send.return_value = child
+
+        result = send_stripe_invoice(self.invoice)
+
+        send.assert_called_once_with("in_revision")
+        self.assertEqual(result.stripe_invoice_id, "in_revision")
+
+    @patch("realestate.stripe_invoices.stripe.Invoice.send_invoice")
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_admin_reminder_action_sends_current_revision(self, retrieve, send):
+        parent, child = self.revision_pair()
+        retrieve.side_effect = lambda stripe_id: {
+            "in_original": parent,
+            "in_revision": child,
+        }[stripe_id]
+        send.return_value = child
+        model_admin = RealEstateInvoiceAdmin(RealEstateInvoice, custom_admin_site)
+        model_admin.message_user = Mock()
+        request = RequestFactory().post("/admin/realestate/invoice/")
+
+        model_admin.send_stripe_reminder_action(
+            request,
+            RealEstateInvoice.objects.filter(pk=self.invoice.pk),
+        )
+
+        send.assert_called_once_with("in_revision")
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_latest_revision_may_jump_to_most_recent_descendant(self, retrieve):
+        original = self.payload(
+            "in_original", status="void", latest_revision="in_revision_2"
+        )
+        revision_1 = self.payload(
+            "in_revision_1",
+            status="void",
+            from_invoice={"action": "revision", "invoice": "in_original"},
+            latest_revision="in_revision_2",
+        )
+        revision_2 = self.payload(
+            "in_revision_2",
+            from_invoice={"action": "revision", "invoice": "in_revision_1"},
+        )
+        retrieve.side_effect = lambda stripe_id: {
+            "in_original": original,
+            "in_revision_1": revision_1,
+            "in_revision_2": revision_2,
+        }[stripe_id]
+
+        self.view._handle_realestate_invoice_event("invoice.voided", original)
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_revision_2")
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.ISSUED)
+
+    def test_ordinary_non_revision_void_still_voids_local_invoice(self):
+        original = self.payload("in_original", status="void")
+
+        self.view._handle_realestate_invoice_event("invoice.voided", original)
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.VOID)
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_forged_metadata_without_revision_relationship_is_rejected(self, retrieve):
+        unrelated = self.payload("in_unrelated")
+
+        with self.assertRaisesMessage(StripeInvoiceRevisionError, "unrelated"):
+            self.view._handle_realestate_invoice_event("invoice.finalized", unrelated)
+        retrieve.assert_not_called()
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_wrong_revision_parent_is_rejected(self, retrieve):
+        unrelated_parent = self.payload(
+            "in_other_parent", latest_revision="in_revision"
+        )
+        child = self.payload(
+            "in_revision",
+            from_invoice={"action": "revision", "invoice": "in_other_parent"},
+        )
+        retrieve.return_value = unrelated_parent
+
+        with self.assertRaisesMessage(StripeInvoiceRevisionError, "unrelated"):
+            self.view._handle_realestate_invoice_event("invoice.finalized", child)
+
+    def test_revision_security_metadata_amount_currency_and_mode_must_match(self):
+        base_metadata = self.payload("in_original")["metadata"]
+        cases = {
+            "enquiry": {"metadata": {**base_metadata, "realestate_enquiry_id": "999"}},
+            "invoice number": {"metadata": {**base_metadata, "realestate_invoice_number": "OTHER"}},
+            "purpose": {"metadata": {**base_metadata, "payment_purpose": "realestate_deposit"}},
+            "amount": {"total": 39899},
+            "amount due": {"amount_due": 39899},
+            "currency": {"currency": "usd"},
+            "environment": {"livemode": True},
+        }
+        for label, overrides in cases.items():
+            with self.subTest(label=label):
+                with self.assertRaises(StripeInvoiceRevisionError):
+                    self.view._handle_realestate_invoice_event(
+                        "invoice.finalized", self.payload("in_original", **overrides)
+                    )
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_manually_voided_and_paid_local_records_are_not_reopened(self, retrieve):
+        parent, child = self.revision_pair()
+        retrieve.return_value = parent
+        self.invoice.status = RealEstateInvoice.Status.VOID
+        self.invoice.save(update_fields=("status", "updated_at"))
+        self.enquiry.timeline_events.create(
+            event_type=RealEstateTimelineEvent.EventType.NOTE,
+            title="Invoice voided",
+            notes=f"Invoice {self.invoice.invoice_number} was voided without a payment record.",
+        )
+
+        self.view._handle_realestate_invoice_event("invoice.finalized", child)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.VOID)
+
+        self.invoice.status = RealEstateInvoice.Status.PAID
+        self.invoice.save(update_fields=("status", "updated_at"))
+        child["id"] = "in_revision_2"
+        child["from_invoice"] = {"action": "revision", "invoice": "in_revision"}
+        current_parent = self.payload("in_revision", latest_revision="in_revision_2")
+        retrieve.return_value = current_parent
+        self.view._handle_realestate_invoice_event("invoice.finalized", child)
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.PAID)
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_verified_open_revision_restores_only_non_manual_void(self, retrieve):
+        parent, child = self.revision_pair()
+        retrieve.return_value = parent
+        self.invoice.status = RealEstateInvoice.Status.VOID
+        self.invoice.save(update_fields=("status", "updated_at"))
+
+        self.view._handle_realestate_invoice_event("invoice.finalized", child)
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.ISSUED)
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_reconciliation_command_dry_run_and_apply_are_idempotent(self, retrieve):
+        parent, child = self.revision_pair()
+        retrieve.side_effect = lambda stripe_id: {
+            "in_original": parent,
+            "in_revision": child,
+        }[stripe_id]
+        output = StringIO()
+
+        call_command(
+            "reconcile_realestate_stripe_invoice_revisions",
+            invoice_number=self.invoice.invoice_number,
+            dry_run=True,
+            stdout=output,
+        )
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_original")
+        self.assertIn("local_invoice_status=issued", output.getvalue())
+        self.assertIn("stored_stripe_invoice_status=open", output.getvalue())
+        self.assertIn("stored_stripe_invoice_id=in_original", output.getvalue())
+        self.assertIn("current_stripe_invoice_id=in_revision", output.getvalue())
+        self.assertIn("current_stripe_invoice_status=open", output.getvalue())
+
+        call_command(
+            "reconcile_realestate_stripe_invoice_revisions",
+            invoice_number=self.invoice.invoice_number,
+            apply=True,
+            stdout=StringIO(),
+        )
+        call_command(
+            "reconcile_realestate_stripe_invoice_revisions",
+            invoice_number=self.invoice.invoice_number,
+            apply=True,
+            stdout=StringIO(),
+        )
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, RealEstateInvoice.Status.ISSUED)
+        self.assertEqual(self.invoice.stripe_invoice_id, "in_revision")
+        self.assertEqual(
+            self.enquiry.timeline_events.filter(
+                title="Stripe invoice revision reconciled"
+            ).count(),
+            1,
+        )
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_reconciliation_command_rejects_cycle(self, retrieve):
+        original = self.payload("in_original", latest_revision="in_revision")
+        revision = self.payload(
+            "in_revision",
+            latest_revision="in_original",
+            from_invoice={"action": "revision", "invoice": "in_original"},
+        )
+        retrieve.side_effect = lambda stripe_id: {
+            "in_original": original,
+            "in_revision": revision,
+        }[stripe_id]
+
+        with self.assertRaisesMessage(CommandError, "cycle"):
+            call_command(
+                "reconcile_realestate_stripe_invoice_revisions",
+                invoice_number=self.invoice.invoice_number,
+                dry_run=True,
+            )
+
+    @patch("realestate.stripe_invoice_revisions.stripe.Invoice.retrieve")
+    def test_reconciliation_command_rejects_excessive_depth(self, retrieve):
+        invoices = {}
+        ids = ["in_original"] + [f"in_revision_{index}" for index in range(1, 10)]
+        for index, stripe_id in enumerate(ids):
+            latest = ids[index + 1] if index + 1 < len(ids) else None
+            from_invoice = (
+                None
+                if index == 0
+                else {"action": "revision", "invoice": ids[index - 1]}
+            )
+            invoices[stripe_id] = self.payload(
+                stripe_id,
+                latest_revision=latest,
+                from_invoice=from_invoice,
+            )
+        retrieve.side_effect = lambda stripe_id: invoices[stripe_id]
+
+        with self.assertRaisesMessage(CommandError, "exceeds 8"):
+            call_command(
+                "reconcile_realestate_stripe_invoice_revisions",
+                invoice_number=self.invoice.invoice_number,
+                dry_run=True,
+            )
 
 
 class RealEstateAdminOperationsHubTests(TestCase):


### PR DESCRIPTION
## Summary

Adds production-safe reconciliation for Stripe Invoice revisions in the real-estate workflow. Legitimate revisions replace the stored external Stripe references without creating another local invoice, while unrelated invoices and malformed chains remain fail-closed.

## Why

Stripe Dashboard revisions void the original invoice and create a new invoice ID. The webhook previously treated the stored Stripe ID as permanently immutable, rejected the revised invoice, and could apply the superseded original invoice's void status to the local business invoice.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - Validate direct and multi-step revision chains using `from_invoice` and `latest_revision`.
  - Enforce exact invoice number, enquiry ID, payment purpose, currency, total, amount due, and Stripe environment matching.
  - Handle original-void/revised-finalized events safely in either order and ignore delayed superseded events.
  - Atomically refresh current Stripe IDs, numbers, hosted/PDF URLs, statuses, and timestamps.
  - Preserve webhook payment locking and idempotency for revised `invoice.paid` events.
  - Reconcile the current revision before reminders and out-of-band settlement.
  - Add an idempotent dry-run/apply management command with audit timeline and structured logging.
  - Add bounded depth and cycle protection.
- Frontend:
  - None.
- Infra/Config:
  - None; no migration required.

## Testing

- [x] Django tests pass locally — 481 tests
- [ ] React build passes locally — not applicable
- [ ] Manual smoke test done — production recovery is intentionally deferred until after deployment
- `python manage.py makemigrations --check`
- `python manage.py check`
- `python manage.py test realestate checkout` — 301 passed
- `python manage.py test` — 481 passed
- `python -m compileall -q realestate checkout`
- `git diff --check`

### Manual smoke test checklist (quick)

- [ ] No console errors — not applicable
- [ ] Forms submit correctly — no form changes
- [x] API errors handled (revision validation fails closed)
- [ ] Mobile layout checked — not applicable
- [x] Auth/permissions verified (existing signature-verified webhook and admin permissions unchanged)

## Risk & Rollback

Risk level: Medium

Revision acceptance is limited to Stripe-verified ancestry and exact local identity, amount, currency, purpose, and environment checks. Chains are bounded to eight revisions with cycle detection. Manual voids, terminal conflicts, partial-payment mismatches, and ambiguous records are not reopened.

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described: revert this PR to restore strict single-Stripe-ID matching, then reconcile affected invoices manually.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (revision ancestry, metadata binding, amount/currency/environment checks)
- [x] Performance (bounded Stripe retrieval and no unbounded chain traversal)
- [x] Maintainability (shared reconciliation logic across webhooks, reminders, and management command)

No production command, invoice send, payment mutation, refund, customer contact, commit deployment, or production data change was performed as part of implementation.