### PR TITLE
Add versioned real-estate package catalogue

### DIFF
--- a/docs/real_estate_email_qa.md
+++ b/docs/real_estate_email_qa.md
@@ -34,6 +34,10 @@ Use this checklist before enabling or changing any real estate email flow in pro
 
 - [ ] Quote emails describe scope and price only, and do not imply the booking is confirmed.
 - [ ] Quote emails include "Ready to proceed?" and explain that the Booking Agreement and booking deposit request are issued after the client replies.
+- [ ] Quote, booking-agreement and confirmation emails show the package-aware standard turnaround: next business day for Essential/Starter, two business days for Pro/Premium, or specifically agreed for Custom/Not sure.
+- [ ] Enquiry, quote, booking-agreement and confirmation emails show the current catalogue's included edited-photograph allowance for new work, while issued historical scope remains unchanged.
+- [ ] Customer-facing scope copy states that additional edited photographs may be agreed at EUR 10 per photograph.
+- [ ] Rush delivery is described as still-photography only and never as rush processing for video, social cuts, virtual tours, floor plans or other Premium outputs.
 - [ ] Quote emails clearly state the booking is confirmed only after both the Booking Agreement is signed and the booking deposit has cleared.
 - [ ] Quote emails include a "Proceed with this quote" mailto button when a reply email is configured.
 - [ ] Quote emails show a safe highlighted fallback message instead of a broken button when no reply email is configured.
@@ -64,6 +68,7 @@ adopting it would change deposit collection, invoice delivery, reminder, and web
 semantics and should be planned as a separate payment-flow migration.
 - [ ] Delivery emails include a "Download Media" CTA when a delivery link is present.
 - [ ] Delivery emails include the agreed commercial marketing licence wording and do not imply ownership transfer.
+- [ ] Delivery emails retain the MyAirBridge three-day link-expiry warning.
 - [ ] Follow-up emails include a "Leave a Google Review" CTA only when a review link exists.
 - [ ] Weather reschedule emails clearly state the proposed replacement date/time and next step.
 

--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -756,7 +756,8 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
             "booking": {
                 "status": enquiry.get_status_display(),
                 "shoot": enquiry.shoot_date or enquiry.preferred_date or "To be confirmed",
-                "package": enquiry.get_preferred_package_display(),
+                "package": enquiry.get_preferred_package_summary(),
+                "turnaround": enquiry.get_preferred_package_turnaround_label(),
                 "arrangement": enquiry.get_payment_arrangement_display(),
                 "expected_method": enquiry.get_expected_payment_method_display() or "Not set",
                 "agreement": "Received" if enquiry.booking_agreement_received else "Pending",

--- a/realestate/docs/booking_agreement.md
+++ b/realestate/docs/booking_agreement.md
@@ -80,6 +80,7 @@ Included Deliverables:
 - Any additional agreed add-ons listed below.
 - Professionally edited property media suitable for marketing the property identified in this Booking Agreement.
 - Any drone, video, social media, floor plan, virtual tour, or additional media outputs only where expressly included in the package or agreed in writing.
+- {{ additional_photograph_copy }}
 
 Additional Agreed Add-Ons:
 
@@ -121,9 +122,9 @@ Only the Deliverables expressly listed above are included in this Booking Agreem
 
 ## 6. Delivery and Editing
 
-6.1 OpenEire shall use reasonable endeavours to deliver the Deliverables within 24 hours of the Shoot Date.
+6.1 Standard turnaround for the selected package: **{{ turnaround_label }}**. {{ turnaround_detail }}
 
-6.2 The Client acknowledges that delivery within 24 hours is conditional upon lawful and safe operating conditions, property access, weather, technical issues, and events outside OpenEire's reasonable control.
+6.2 {{ turnaround_context }}
 
 6.3 Deliverables shall be supplied in OpenEire's standard professional editing style.
 

--- a/realestate/docs/package_catalogue_rollout.md
+++ b/realestate/docs/package_catalogue_rollout.md
@@ -1,0 +1,66 @@
+# Real-estate package catalogue rollout
+
+## Effective scope
+
+The photograph allowances in `realestate.package_catalogue` apply to enquiries
+quoted or contracted after the backend catalogue release is deployed:
+
+- Essential: 10 professionally edited interior and exterior photographs
+- Starter: 25 professionally edited interior and exterior photographs
+- Pro: 30 professionally edited interior and exterior photographs
+- Premium: 35 professionally edited interior and exterior photographs
+- Custom / Not sure: specifically agreed
+
+Package prices, other deliverables, add-ons, travel rules, and package-aware
+turnaround are unchanged. Additional edited photographs remain EUR 10 per
+photograph.
+
+## Historical protection
+
+An issued Booking Agreement snapshot is the contractual source for an existing
+booking. Customer and operations workflows resolve package scope from the
+latest snapshot context and never rebuild that scope from the current
+catalogue.
+
+For booked or completed records without a recoverable agreement snapshot,
+package-scope rendering fails closed with an instruction to verify the issued
+quotation or agreement. An operator must confirm and persist the agreed scope
+before using it in a new client communication or regenerated document.
+
+Known historical scopes that must not be changed:
+
+- Kevin's completed Pro booking: 25 photographs
+- Kathleen's completed Pro booking: 25 photographs
+- Brid's Willow Lodge Starter booking: 20 photographs
+- Brid's 6 Waters Edge Starter booking: 20 photographs
+
+No migration backfills or rewrites existing snapshots, timelines, invoices, or
+communications.
+
+## Agreement version
+
+New Booking Agreement snapshots use template version 1.8. Versions 1.6 and 1.7
+remain immutable stored Markdown and continue to render byte-for-byte from
+their snapshots.
+
+Migration `0023` changes only the model-field default for new snapshot rows.
+It contains no data operation.
+
+## Deployment order
+
+1. Deploy the backend and apply schema migration `0023`.
+2. Verify the public enquiry API returns the new catalogue values and that a
+   test version-1.8 agreement renders correctly.
+3. Deploy the frontend.
+4. Verify package cards, enquiry guidance, metadata/JSON-LD, and a test
+   submission in production-safe QA.
+
+The backend-first order makes the API authoritative before the public site
+advertises the revised allowances.
+
+## Manually maintained materials
+
+Before launch, check any material outside these repositories, including sales
+PDFs, saved email snippets, CRM templates, proposal templates, price sheets,
+social posts, marketplace listings, and staff operating notes. Issued or
+signed historical material must not be edited.

--- a/realestate/documents.py
+++ b/realestate/documents.py
@@ -17,6 +17,7 @@ from .models import (
     RealEstateInvoice,
 )
 from .payments import calculate_realestate_deposit_amounts
+from .turnaround import TURNAROUND_CONTEXT
 
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
@@ -356,6 +357,14 @@ def _build_booking_agreement_context(enquiry):
             if hasattr(enquiry, "get_preferred_package_summary")
             else getattr(enquiry, "preferred_package", "")
         ),
+        "included_photographs_label": enquiry.get_included_photographs_label(),
+        "included_photograph_count": enquiry.get_included_photograph_count(),
+        "additional_photograph_copy": _agreement_currency_text(
+            enquiry.ADDITIONAL_PHOTOGRAPH_COPY
+        ),
+        "turnaround_label": enquiry.get_preferred_package_turnaround_label(),
+        "turnaround_detail": enquiry.get_preferred_package_turnaround_detail(),
+        "turnaround_context": TURNAROUND_CONTEXT,
         "add_ons_summary": _agreement_currency_text(
             enquiry.get_add_ons_summary()
             if hasattr(enquiry, "get_add_ons_summary")

--- a/realestate/emails.py
+++ b/realestate/emails.py
@@ -17,6 +17,7 @@ from django.urls import reverse
 
 from openeire_api.mail_utils import get_default_from_email
 from .models import RealEstateEnquiry, RealEstateInvoice, RealEstatePayment
+from .turnaround import TURNAROUND_CONTEXT
 
 
 logger = logging.getLogger(__name__)
@@ -331,6 +332,27 @@ def build_realestate_email_context(enquiry, **overrides):
             if hasattr(enquiry, "get_preferred_package_summary")
             else ""
         ),
+        "included_photographs_label": (
+            enquiry.get_included_photographs_label()
+            if hasattr(enquiry, "get_included_photographs_label")
+            else ""
+        ),
+        "additional_photograph_copy": getattr(
+            enquiry,
+            "ADDITIONAL_PHOTOGRAPH_COPY",
+            "Additional edited photographs may be agreed at EUR 10 per photograph.",
+        ),
+        "turnaround_label": (
+            enquiry.get_preferred_package_turnaround_label()
+            if hasattr(enquiry, "get_preferred_package_turnaround_label")
+            else ""
+        ),
+        "turnaround_detail": (
+            enquiry.get_preferred_package_turnaround_detail()
+            if hasattr(enquiry, "get_preferred_package_turnaround_detail")
+            else ""
+        ),
+        "turnaround_context": TURNAROUND_CONTEXT,
         "addons": enquiry.get_add_on_labels()
         if hasattr(enquiry, "get_add_on_labels")
         else [],
@@ -399,6 +421,8 @@ def send_realestate_internal_notification_email(enquiry, request=None):
         f"Precise location details: {enquiry.location_details or 'Not provided'}\n\n"
         "Requested package\n"
         f"Package: {enquiry.get_preferred_package_summary()}\n"
+        f"Included photographs: {enquiry.get_included_photographs_label()}\n"
+        f"Standard turnaround: {enquiry.get_preferred_package_turnaround_label()}\n"
         f"Add-ons: {enquiry.get_add_ons_summary()}\n"
         f"Additional stills quantity: {enquiry.additional_stills_quantity or 'Not applicable'}\n\n"
         "Property size / scope\n"

--- a/realestate/financial_documents.py
+++ b/realestate/financial_documents.py
@@ -38,9 +38,7 @@ def build_invoice_filename(invoice):
 
 def generate_invoice_pdf(invoice):
     enquiry = invoice.enquiry
-    deliverables = {
-        "pro": "25 edited interior/exterior photographs; 5–8 aerial stills; ground/aerial video; social cuts; commercial marketing licence",
-    }.get(enquiry.preferred_package, enquiry.get_preferred_package_summary())
+    deliverables = enquiry.get_preferred_package_summary()
     payment_refs = ", ".join(
         filter(None, invoice.payments.filter(status="succeeded").values_list("external_reference", flat=True))
     ) or "—"

--- a/realestate/migrations/0022_alter_realestatebookingagreementsnapshot_template_version.py
+++ b/realestate/migrations/0022_alter_realestatebookingagreementsnapshot_template_version.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("realestate", "0021_realestateenquiry_form_schema_version"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="realestatebookingagreementsnapshot",
+            name="template_version",
+            field=models.CharField(default="1.7", max_length=16),
+        ),
+    ]

--- a/realestate/migrations/0023_alter_realestatebookingagreementsnapshot_template_version.py
+++ b/realestate/migrations/0023_alter_realestatebookingagreementsnapshot_template_version.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "realestate",
+            "0022_alter_realestatebookingagreementsnapshot_template_version",
+        ),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="realestatebookingagreementsnapshot",
+            name="template_version",
+            field=models.CharField(default="1.8", max_length=16),
+        ),
+    ]

--- a/realestate/models.py
+++ b/realestate/models.py
@@ -4,6 +4,20 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import Q, Sum
 from decimal import Decimal
+import re
+
+from .package_catalogue import (
+    ADDITIONAL_PHOTOGRAPH_COPY,
+    PACKAGE_SUMMARIES,
+    get_included_photograph_count,
+    get_included_photographs_label,
+    get_package_summary,
+)
+from .turnaround import (
+    get_package_turnaround_code,
+    get_package_turnaround_detail,
+    get_package_turnaround_label,
+)
 
 
 class RealEstateEnquiry(models.Model):
@@ -130,23 +144,17 @@ class RealEstateEnquiry(models.Model):
         OTHER = "other", "Other"
 
     ADD_ON_LABELS = {
-        "additional_stills": "Additional edited stills - EUR 10 per image",
+        "additional_stills": "Additional edited photographs - EUR 10 per photograph",
         "floor_plan": "Floor plan, 2D measured - EUR 75",
         "virtual_tour_3d": "Hosted 3D virtual tour - EUR 150",
-        "rush_delivery": "Rush same-day delivery, stills only - EUR 75",
+        "rush_delivery": "Rush same-day delivery, still photography only - EUR 75",
         "extended_drone_video": "Extended drone video, up to 3 minutes - EUR 150",
         "additional_social_cuts": "Additional social media cuts - EUR 50",
         "travel_supplement": "Travel supplement beyond 40 km - EUR 0.50 per km",
     }
 
-    PACKAGE_SUMMARIES = {
-        PreferredPackage.ESSENTIAL: "Essential - EUR 175 - 10 edited interior/exterior photos",
-        PreferredPackage.STARTER: "Starter - EUR 229 - 20 edited interior/exterior photos + 5-8 aerial drone photos",
-        PreferredPackage.PRO: "Pro - EUR 399 - 25 edited interior/exterior photos + 5-8 aerial drone photos + 60-90s ground video + 60-90s 4K aerial drone video + standard portrait and square social cuts",
-        PreferredPackage.PREMIUM: "Premium - EUR 579 - 30 edited interior/exterior photos + 5-8 aerial drone photos + ground video + aerial drone video + standard social cuts + hosted 3D virtual tour + 2D measured floor plan",
-        PreferredPackage.CUSTOM: "Custom - POA",
-        PreferredPackage.NOT_SURE: "Not sure yet",
-    }
+    PACKAGE_SUMMARIES = PACKAGE_SUMMARIES
+    ADDITIONAL_PHOTOGRAPH_COPY = ADDITIONAL_PHOTOGRAPH_COPY
 
     name = models.CharField(max_length=255)
     email = models.EmailField()
@@ -339,7 +347,71 @@ class RealEstateEnquiry(models.Model):
         return f"[{self.county}] {self.get_preferred_package_display()} - {self.name}"
 
     def get_preferred_package_summary(self):
-        return self.PACKAGE_SUMMARIES.get(self.preferred_package, self.get_preferred_package_display())
+        persisted_scope = self._get_persisted_package_scope()
+        if persisted_scope:
+            return persisted_scope.get("package_name") or (
+                "Agreed package scope - refer to the issued Booking Agreement"
+            )
+        if self._requires_historical_scope_review():
+            return "Agreed package scope - verify the issued quotation or agreement"
+        return get_package_summary(
+            self.preferred_package,
+            self.get_preferred_package_display(),
+        )
+
+    def get_included_photographs_label(self):
+        persisted_scope = self._get_persisted_package_scope()
+        if persisted_scope:
+            label = persisted_scope.get("included_photographs_label")
+            if label:
+                return label
+            package_name = str(persisted_scope.get("package_name") or "")
+            match = re.search(r"(\d+)\s+(?:professionally\s+)?edited", package_name, re.I)
+            if match:
+                return (
+                    f"{match.group(1)} professionally edited interior "
+                    "and exterior photographs"
+                )
+            return "Included photographs - refer to the issued Booking Agreement"
+        if self._requires_historical_scope_review():
+            return "Included photographs - verify the issued quotation or agreement"
+        return get_included_photographs_label(self.preferred_package)
+
+    def get_included_photograph_count(self):
+        persisted_scope = self._get_persisted_package_scope()
+        if persisted_scope:
+            count = persisted_scope.get("included_photograph_count")
+            if isinstance(count, int):
+                return count
+            match = re.search(
+                r"(\d+)\s+(?:professionally\s+)?edited",
+                str(persisted_scope.get("package_name") or ""),
+                re.I,
+            )
+            return int(match.group(1)) if match else None
+        if self._requires_historical_scope_review():
+            return None
+        return get_included_photograph_count(self.preferred_package)
+
+    def _get_persisted_package_scope(self):
+        if not self.pk:
+            return None
+        snapshot = self.booking_agreement_snapshots.first()
+        if not snapshot:
+            return None
+        return snapshot.context if isinstance(snapshot.context, dict) else {}
+
+    def _requires_historical_scope_review(self):
+        return self.status in {self.Status.BOOKED, self.Status.COMPLETED}
+
+    def get_preferred_package_turnaround_code(self):
+        return get_package_turnaround_code(self.preferred_package)
+
+    def get_preferred_package_turnaround_label(self):
+        return get_package_turnaround_label(self.preferred_package)
+
+    def get_preferred_package_turnaround_detail(self):
+        return get_package_turnaround_detail(self.preferred_package)
 
     def get_add_on_labels(self):
         labels = []
@@ -485,7 +557,7 @@ class RealEstateDocumentSequence(models.Model):
 
 
 class RealEstateBookingAgreementSnapshot(models.Model):
-    TEMPLATE_VERSION = "1.6"
+    TEMPLATE_VERSION = "1.8"
 
     enquiry = models.ForeignKey(
         RealEstateEnquiry,

--- a/realestate/package_catalogue.py
+++ b/realestate/package_catalogue.py
@@ -1,0 +1,99 @@
+from dataclasses import dataclass
+
+
+ADDITIONAL_PHOTOGRAPH_PRICE_EUR = 10
+ADDITIONAL_PHOTOGRAPH_COPY = (
+    "Additional edited photographs may be agreed at EUR 10 per photograph."
+)
+
+
+@dataclass(frozen=True)
+class RealEstatePackage:
+    name: str
+    price_eur: int | None
+    included_photographs: int | None
+    other_deliverables: str = ""
+
+    @property
+    def included_photographs_label(self):
+        if self.included_photographs is None:
+            return "Included photographs as specifically agreed"
+        return (
+            f"{self.included_photographs} professionally edited interior "
+            "and exterior photographs"
+        )
+
+    @property
+    def summary(self):
+        price = f"EUR {self.price_eur}" if self.price_eur is not None else "POA"
+        scope = self.included_photographs_label
+        if self.other_deliverables:
+            scope = f"{scope} + {self.other_deliverables}"
+        return f"{self.name} - {price} - {scope}"
+
+
+REAL_ESTATE_PACKAGE_CATALOGUE = {
+    "essential": RealEstatePackage(
+        name="Essential",
+        price_eur=175,
+        included_photographs=10,
+    ),
+    "starter": RealEstatePackage(
+        name="Starter",
+        price_eur=229,
+        included_photographs=25,
+        other_deliverables="5-8 aerial drone photographs",
+    ),
+    "pro": RealEstatePackage(
+        name="Pro",
+        price_eur=399,
+        included_photographs=30,
+        other_deliverables=(
+            "5-8 aerial drone photographs + 60-90s ground video + "
+            "60-90s 4K aerial drone video + standard portrait and square social cuts"
+        ),
+    ),
+    "premium": RealEstatePackage(
+        name="Premium",
+        price_eur=579,
+        included_photographs=35,
+        other_deliverables=(
+            "5-8 aerial drone photographs + ground video + aerial drone video + "
+            "standard social cuts + hosted 3D virtual tour + 2D measured floor plan"
+        ),
+    ),
+    "custom": RealEstatePackage(
+        name="Custom",
+        price_eur=None,
+        included_photographs=None,
+    ),
+    "not_sure": RealEstatePackage(
+        name="Not sure yet",
+        price_eur=None,
+        included_photographs=None,
+    ),
+}
+
+PACKAGE_SUMMARIES = {
+    package_code: package.summary
+    for package_code, package in REAL_ESTATE_PACKAGE_CATALOGUE.items()
+}
+
+
+def get_package(package_code):
+    return REAL_ESTATE_PACKAGE_CATALOGUE.get(package_code)
+
+
+def get_package_summary(package_code, fallback=""):
+    package = get_package(package_code)
+    return package.summary if package else fallback
+
+
+def get_included_photographs_label(package_code, fallback="Specifically agreed"):
+    package = get_package(package_code)
+    return package.included_photographs_label if package else fallback
+
+
+def get_included_photograph_count(package_code):
+    package = get_package(package_code)
+    return package.included_photographs if package else None

--- a/realestate/serializers.py
+++ b/realestate/serializers.py
@@ -64,6 +64,27 @@ class RealEstateEnquirySerializer(serializers.ModelSerializer):
         allow_empty=True,
         default=list,
     )
+    package_summary = serializers.CharField(
+        source="get_preferred_package_summary",
+        read_only=True,
+    )
+    turnaround_code = serializers.CharField(
+        source="get_preferred_package_turnaround_code",
+        read_only=True,
+    )
+    turnaround_label = serializers.CharField(
+        source="get_preferred_package_turnaround_label",
+        read_only=True,
+    )
+    included_photograph_count = serializers.IntegerField(
+        source="get_included_photograph_count",
+        read_only=True,
+        allow_null=True,
+    )
+    included_photographs_label = serializers.CharField(
+        source="get_included_photographs_label",
+        read_only=True,
+    )
 
     class Meta:
         model = RealEstateEnquiry
@@ -81,7 +102,9 @@ class RealEstateEnquirySerializer(serializers.ModelSerializer):
             "additional_stills_quantity", "scheduling_preference",
             "preferred_date", "alternative_date", "preferred_time_window",
             "on_camera", "on_camera_people", "audio_requirements", "how_heard",
-            "message", "consent_to_contact", "status",
+            "message", "consent_to_contact", "status", "package_summary",
+            "included_photograph_count", "included_photographs_label",
+            "turnaround_code", "turnaround_label",
         )
         read_only_fields = ("id", "status")
         extra_kwargs = {
@@ -245,7 +268,7 @@ class RealEstateEnquirySerializer(serializers.ModelSerializer):
         quantity = attrs.get("additional_stills_quantity")
         if "additional_stills" in add_ons and quantity is None:
             errors["additional_stills_quantity"] = (
-                "Choose how many additional edited stills are required (maximum 50)."
+                "Choose how many additional edited photographs are required (maximum 50)."
             )
         elif "additional_stills" not in add_ons and quantity is not None:
             errors["additional_stills_quantity"] = (

--- a/realestate/tests.py
+++ b/realestate/tests.py
@@ -39,6 +39,19 @@ from .models import RealEstateTimelineEvent
 from .payments import calculate_realestate_deposit_amounts
 from .payments import create_realestate_deposit_checkout_session
 from .payments import prepare_realestate_deposit_checkout_session
+from .package_catalogue import (
+    ADDITIONAL_PHOTOGRAPH_PRICE_EUR,
+    REAL_ESTATE_PACKAGE_CATALOGUE,
+)
+from .turnaround import (
+    NEXT_BUSINESS_DAY,
+    SPECIFICALLY_AGREED,
+    TURNAROUND_CONTEXT,
+    TWO_BUSINESS_DAYS,
+    get_package_turnaround_code,
+    get_package_turnaround_detail,
+    get_package_turnaround_label,
+)
 
 
 REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT = {
@@ -47,6 +60,18 @@ REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT = {
     "company_name": "Example Estate Agents",
     "property_address": "Example House, Salthill, Galway",
     "package_name": "Pro package",
+    "included_photographs_label": (
+        "30 professionally edited interior and exterior photographs"
+    ),
+    "additional_photograph_copy": (
+        "Additional edited photographs may be agreed at EUR 10 per photograph."
+    ),
+    "turnaround_label": "Delivery within 2 business days",
+    "turnaround_detail": (
+        "This package is normally delivered within two business days due to the "
+        "additional video-production workload."
+    ),
+    "turnaround_context": TURNAROUND_CONTEXT,
     "addons": ["2D measured floor plan", "Additional social media cuts"],
     "quote_total": "399",
     "vat_total": "0.00",
@@ -74,6 +99,32 @@ REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT = {
     "cta_url": "",
     "cta_label": "",
 }
+
+
+class RealEstateTurnaroundPolicyTests(SimpleTestCase):
+    def test_package_turnaround_mapping_is_explicit(self):
+        expected = {
+            "essential": (NEXT_BUSINESS_DAY, "Next-business-day delivery"),
+            "starter": (NEXT_BUSINESS_DAY, "Next-business-day delivery"),
+            "pro": (TWO_BUSINESS_DAYS, "Delivery within 2 business days"),
+            "premium": (TWO_BUSINESS_DAYS, "Delivery within 2 business days"),
+            "custom": (SPECIFICALLY_AGREED, "Turnaround as specifically agreed"),
+            "not_sure": (
+                SPECIFICALLY_AGREED,
+                "Turnaround as specifically agreed",
+            ),
+        }
+
+        for package, (code, label) in expected.items():
+            with self.subTest(package=package):
+                self.assertEqual(get_package_turnaround_code(package), code)
+                self.assertEqual(get_package_turnaround_label(package), label)
+
+    def test_rush_delivery_is_still_photography_only(self):
+        label = RealEstateEnquiry.ADD_ON_LABELS["rush_delivery"]
+
+        self.assertIn("still photography only", label)
+        self.assertNotIn("video", label.lower())
 
 
 class RealEstatePricingTests(TestCase):
@@ -532,6 +583,52 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
                 self.assertNotIn("{{", html)
                 self.assertNotIn("{{", text)
 
+    def test_scope_emails_match_catalogue_in_html_and_plain_text(self):
+        for template_name in (
+            "enquiry_reply",
+            "quote",
+            "booking_agreement",
+            "confirmation",
+        ):
+            with self.subTest(template_name=template_name):
+                html = render_to_string(
+                    f"emails/real_estate/{template_name}.html",
+                    REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
+                )
+                text = render_to_string(
+                    f"emails/real_estate/{template_name}.txt",
+                    REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
+                )
+                for rendered in (html, text):
+                    self.assertIn(
+                        "30 professionally edited interior and exterior photographs",
+                        rendered,
+                    )
+                    self.assertIn("EUR 10 per photograph", rendered)
+
+    def test_quote_email_formats_render_every_fixed_package_allowance(self):
+        for package_code, expected in {
+            "essential": 10,
+            "starter": 25,
+            "pro": 30,
+            "premium": 35,
+        }.items():
+            package = REAL_ESTATE_PACKAGE_CATALOGUE[package_code]
+            context = {
+                **REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
+                "package_name": package.summary,
+                "included_photographs_label": package.included_photographs_label,
+            }
+            with self.subTest(package_code=package_code):
+                html = render_to_string("emails/real_estate/quote.html", context)
+                text = render_to_string("emails/real_estate/quote.txt", context)
+                expected_copy = (
+                    f"{expected} professionally edited interior and exterior "
+                    "photographs"
+                )
+                self.assertIn(expected_copy, html)
+                self.assertIn(expected_copy, text)
+
     def test_base_template_renders_logo_when_logo_url_exists(self):
         html = render_to_string(
             "emails/base_email.html",
@@ -699,6 +796,35 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
         self.assertIn("mailto:shoots@openeire.ie", html)
         self.assertIn("Package total: €399.00", text)
         self.assertIn("Proceed with this quote: shoots@openeire.ie", text)
+
+    def test_quote_and_confirmation_formats_use_package_aware_turnaround(self):
+        expected = {
+            "essential": "Next-business-day delivery",
+            "starter": "Next-business-day delivery",
+            "pro": "Delivery within 2 business days",
+            "premium": "Delivery within 2 business days",
+            "custom": "Turnaround as specifically agreed",
+            "not_sure": "Turnaround as specifically agreed",
+        }
+
+        for package, label in expected.items():
+            context = {
+                **REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT,
+                "turnaround_label": label,
+                "turnaround_detail": get_package_turnaround_detail(package),
+            }
+            with self.subTest(package=package):
+                for template_name in ("quote", "confirmation"):
+                    html = render_to_string(
+                        f"emails/real_estate/{template_name}.html",
+                        context,
+                    )
+                    text = render_to_string(
+                        f"emails/real_estate/{template_name}.txt",
+                        context,
+                    )
+                    self.assertIn(f"Standard turnaround:</strong> {label}", html)
+                    self.assertIn(f"Standard turnaround: {label}", text)
 
     def test_full_on_shoot_day_email_templates_render_payment_rule(self):
         context = {
@@ -1073,6 +1199,73 @@ class BookingAgreementDocumentTests(TestCase):
         self.assertNotIn("To be confirmed", rendered)
         self.assertNotIn("To be confirmed by the Client", rendered)
 
+    def test_new_booking_agreements_use_package_aware_turnaround(self):
+        expected = {
+            RealEstateEnquiry.PreferredPackage.ESSENTIAL: (
+                "Next-business-day delivery"
+            ),
+            RealEstateEnquiry.PreferredPackage.STARTER: (
+                "Next-business-day delivery"
+            ),
+            RealEstateEnquiry.PreferredPackage.PRO: (
+                "Delivery within 2 business days"
+            ),
+            RealEstateEnquiry.PreferredPackage.PREMIUM: (
+                "Delivery within 2 business days"
+            ),
+            RealEstateEnquiry.PreferredPackage.CUSTOM: (
+                "Turnaround as specifically agreed"
+            ),
+            RealEstateEnquiry.PreferredPackage.NOT_SURE: (
+                "Turnaround as specifically agreed"
+            ),
+        }
+
+        for index, (package, label) in enumerate(expected.items()):
+            enquiry = RealEstateEnquiry.objects.create(
+                name=f"Turnaround Client {index}",
+                email=f"turnaround-{index}@example.com",
+                phone="+353 87 123 4567",
+                client_type=RealEstateEnquiry.ClientType.PRIVATE_SELLER,
+                property_address=f"Turnaround Property {index}",
+                county="Galway",
+                property_type="Detached house",
+                preferred_package=package,
+                consent_to_contact=True,
+            )
+
+            with self.subTest(package=package):
+                rendered = self._render_booking_agreement_markdown(enquiry)
+                self.assertIn(
+                    f"Standard turnaround for the selected package: **{label}**",
+                    rendered,
+                )
+                self.assertNotIn(
+                    "deliver the Deliverables within 24 hours of the Shoot Date",
+                    rendered,
+                )
+                self.assertIn(TURNAROUND_CONTEXT, rendered)
+
+    def test_delivery_defect_reporting_window_remains_24_hours(self):
+        enquiry = RealEstateEnquiry.objects.create(
+            name="Technical Window Client",
+            email="technical-window@example.com",
+            phone="+353 87 123 4567",
+            client_type=RealEstateEnquiry.ClientType.PRIVATE_SELLER,
+            property_address="Technical Window Property",
+            county="Galway",
+            property_type="Detached house",
+            preferred_package=RealEstateEnquiry.PreferredPackage.ESSENTIAL,
+            consent_to_contact=True,
+        )
+
+        rendered = self._render_booking_agreement_markdown(enquiry)
+
+        self.assertIn(
+            "must be notified within 24 hours of delivery",
+            rendered,
+        )
+
     def test_booking_agreement_quote_amounts_and_signatures_render(self):
         enquiry = RealEstateEnquiry.objects.create(
             name="Jane Agent",
@@ -1254,7 +1447,11 @@ class BookingAgreementDocumentTests(TestCase):
 
         self.assertEqual(first, second)
         snapshot = RealEstateBookingAgreementSnapshot.objects.get(enquiry=enquiry)
-        self.assertEqual(snapshot.template_version, "1.6")
+        self.assertEqual(snapshot.template_version, "1.8")
+        self.assertIn(
+            "30 professionally edited interior and exterior photographs",
+            first,
+        )
         self.assertEqual(snapshot.payment_arrangement, RealEstateEnquiry.PaymentArrangement.FULL_ON_SHOOT_DAY)
         self.assertEqual(snapshot.total_required, Decimal("399.00"))
         self.assertEqual(snapshot.payment_due_date.isoformat(), "2026-07-21")
@@ -1298,13 +1495,113 @@ class BookingAgreementDocumentTests(TestCase):
         new_snapshot = enquiry.booking_agreement_snapshots.latest("created_at")
         self.assertEqual(unchanged_issued_markdown, issued_markdown)
         self.assertEqual(issued_snapshot.rendered_markdown, issued_markdown)
-        self.assertEqual(issued_snapshot.template_version, "1.6")
-        self.assertEqual(new_snapshot.template_version, "1.6")
+        self.assertEqual(issued_snapshot.template_version, "1.8")
+        self.assertEqual(new_snapshot.template_version, "1.8")
         self.assertNotIn("Travel supplement beyond 40 km", issued_markdown)
         self.assertIn("Floor plan, 2D measured - €75", new_markdown)
         self.assertIn("Travel supplement beyond 40 km - €0.50 per km", new_markdown)
         self.assertIn("| Travel supplement included | €65.00 |", new_markdown)
         self.assertEqual(enquiry.booking_agreement_snapshots.count(), 2)
+
+    def test_preexisting_version_1_6_snapshot_remains_unchanged(self):
+        enquiry = RealEstateEnquiry.objects.create(
+            name="Historical Agreement Client",
+            email="historical-agreement@example.com",
+            phone="+353 87 123 4567",
+            client_type=RealEstateEnquiry.ClientType.PRIVATE_SELLER,
+            property_address="Historical Agreement Property",
+            county="Galway",
+            property_type="Detached house",
+            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            consent_to_contact=True,
+        )
+        historical_markdown = (
+            "Version 1.6 issued agreement.\n\n"
+            "OpenEire shall use reasonable endeavours to deliver the Deliverables "
+            "within 24 hours of the Shoot Date."
+        )
+        snapshot = RealEstateBookingAgreementSnapshot.objects.create(
+            enquiry=enquiry,
+            template_version="1.6",
+            payment_arrangement=enquiry.payment_arrangement,
+            context={"agreement_template_version": "1.6"},
+            rendered_markdown=historical_markdown,
+        )
+
+        rendered = render_booking_agreement_markdown(enquiry)
+
+        snapshot.refresh_from_db()
+        self.assertEqual(rendered.encode(), historical_markdown.encode())
+        self.assertEqual(
+            snapshot.rendered_markdown.encode(),
+            historical_markdown.encode(),
+        )
+        self.assertEqual(snapshot.template_version, "1.6")
+
+    def test_preexisting_version_1_7_snapshot_remains_byte_for_byte_unchanged(self):
+        enquiry = RealEstateEnquiry.objects.create(
+            name="Version 1.7 Client",
+            email="version-17@example.com",
+            phone="+353 87 123 4567",
+            client_type=RealEstateEnquiry.ClientType.PRIVATE_SELLER,
+            property_address="Version 1.7 Property",
+            county="Galway",
+            property_type="Detached house",
+            preferred_package=RealEstateEnquiry.PreferredPackage.STARTER,
+            consent_to_contact=True,
+        )
+        historical_markdown = (
+            "Version 1.7 issued agreement.\r\n"
+            "Starter - EUR 229 - 20 edited interior/exterior photos\r\n"
+            "Next-business-day delivery.\r\n"
+        )
+        snapshot = RealEstateBookingAgreementSnapshot.objects.create(
+            enquiry=enquiry,
+            template_version="1.7",
+            payment_arrangement=enquiry.payment_arrangement,
+            context={
+                "agreement_template_version": "1.7",
+                "package_name": (
+                    "Starter - EUR 229 - 20 edited interior/exterior photos"
+                ),
+            },
+            rendered_markdown=historical_markdown,
+        )
+
+        rendered = render_booking_agreement_markdown(enquiry)
+
+        snapshot.refresh_from_db()
+        self.assertEqual(rendered.encode(), historical_markdown.encode())
+        self.assertEqual(
+            snapshot.rendered_markdown.encode(),
+            historical_markdown.encode(),
+        )
+        self.assertEqual(enquiry.get_included_photograph_count(), 20)
+        self.assertIn("20 edited", enquiry.get_preferred_package_summary())
+        email_context = build_realestate_email_context(enquiry)
+        self.assertIn("20 edited", email_context["package_name"])
+        self.assertEqual(
+            email_context["included_photographs_label"],
+            "20 professionally edited interior and exterior photographs",
+        )
+
+    def test_completed_booking_without_persisted_scope_fails_closed(self):
+        enquiry = RealEstateEnquiry.objects.create(
+            name="Historical Pro Client",
+            email="historical-pro@example.com",
+            phone="+353 87 123 4567",
+            client_type=RealEstateEnquiry.ClientType.PRIVATE_SELLER,
+            property_address="Historical Pro Property",
+            county="Galway",
+            property_type="Detached house",
+            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            status=RealEstateEnquiry.Status.COMPLETED,
+            consent_to_contact=True,
+        )
+
+        self.assertIsNone(enquiry.get_included_photograph_count())
+        self.assertIn("verify", enquiry.get_preferred_package_summary())
+        self.assertNotIn("30 professionally", enquiry.get_preferred_package_summary())
 
     def test_travel_agreement_requires_exact_amount_and_details(self):
         enquiry = RealEstateEnquiry.objects.create(
@@ -1456,6 +1753,22 @@ class RealEstateEnquiryTests(APITestCase):
         self.assertEqual(response.data["id"], enquiry.id)
         self.assertEqual(response.data["status"], "new")
         self.assertEqual(response.data["message"], "Enquiry received successfully.")
+        self.assertEqual(
+            response.data["package_summary"],
+            RealEstateEnquiry.PACKAGE_SUMMARIES[
+                RealEstateEnquiry.PreferredPackage.PRO
+            ],
+        )
+        self.assertEqual(response.data["turnaround_code"], TWO_BUSINESS_DAYS)
+        self.assertEqual(
+            response.data["turnaround_label"],
+            "Delivery within 2 business days",
+        )
+        self.assertEqual(response.data["included_photograph_count"], 30)
+        self.assertEqual(
+            response.data["included_photographs_label"],
+            "30 professionally edited interior and exterior photographs",
+        )
         self.assertNotIn("internal_notes", response.data)
         for private_pricing_field in (
             "quoted_price",
@@ -1478,6 +1791,10 @@ class RealEstateEnquiryTests(APITestCase):
         self.assertEqual(event.actor_type, RealEstateTimelineEvent.ActorType.CLIENT)
         self.assertEqual(event.title, "Enquiry received")
         self.assertIn("Preferred package: Pro", event.notes)
+        self.assertIn(
+            "Standard turnaround: Delivery within 2 business days",
+            event.notes,
+        )
         self.assertIn("Property address: Example House, Salthill, Galway", event.notes)
 
     def test_deployed_legacy_payload_remains_accepted_during_rollout(self):
@@ -1556,6 +1873,10 @@ class RealEstateEnquiryTests(APITestCase):
             internal_email.subject,
         )
         self.assertIn("Jane Agent", internal_email.body)
+        self.assertIn(
+            "Standard turnaround: Delivery within 2 business days",
+            internal_email.body,
+        )
         self.assertIn("View in admin:", internal_email.body)
 
     def test_client_confirmation_email_is_sent(self):
@@ -1570,8 +1891,16 @@ class RealEstateEnquiryTests(APITestCase):
             client_email.subject,
         )
         self.assertIn("Example House, Salthill, Galway", client_email.body)
+        self.assertIn(
+            "Standard turnaround: Delivery within 2 business days",
+            client_email.body,
+        )
         self.assertEqual(len(client_email.alternatives), 1)
         self.assertEqual(client_email.alternatives[0][1], "text/html")
+        self.assertIn(
+            "Standard turnaround:</strong> Delivery within 2 business days",
+            client_email.alternatives[0][0],
+        )
 
     def test_consent_to_contact_false_is_rejected(self):
         payload = {**self.payload, "consent_to_contact": False}
@@ -1837,6 +2166,33 @@ class RealEstateEnquiryTests(APITestCase):
         self.assertIn("ground video", RealEstateEnquiry.PACKAGE_SUMMARIES["pro"])
         self.assertIn("ground video", RealEstateEnquiry.PACKAGE_SUMMARIES["premium"])
         self.assertIn("2D measured floor plan", RealEstateEnquiry.PACKAGE_SUMMARIES["premium"])
+
+    def test_authoritative_package_catalogue_preserves_prices_and_new_allowances(self):
+        self.assertEqual(
+            {
+                code: (package.price_eur, package.included_photographs)
+                for code, package in REAL_ESTATE_PACKAGE_CATALOGUE.items()
+            },
+            {
+                "essential": (175, 10),
+                "starter": (229, 25),
+                "pro": (399, 30),
+                "premium": (579, 35),
+                "custom": (None, None),
+                "not_sure": (None, None),
+            },
+        )
+        self.assertEqual(ADDITIONAL_PHOTOGRAPH_PRICE_EUR, 10)
+        for code, expected in {
+            "essential": 10,
+            "starter": 25,
+            "pro": 30,
+            "premium": 35,
+        }.items():
+            self.assertIn(
+                f"{expected} professionally edited interior and exterior photographs",
+                RealEstateEnquiry.PACKAGE_SUMMARIES[code],
+            )
 
     @patch(
         "realestate.views.send_realestate_internal_notification_email",

--- a/realestate/turnaround.py
+++ b/realestate/turnaround.py
@@ -1,0 +1,49 @@
+NEXT_BUSINESS_DAY = "next_business_day"
+TWO_BUSINESS_DAYS = "two_business_days"
+SPECIFICALLY_AGREED = "specifically_agreed"
+
+PACKAGE_TURNAROUND_CODES = {
+    "essential": NEXT_BUSINESS_DAY,
+    "starter": NEXT_BUSINESS_DAY,
+    "pro": TWO_BUSINESS_DAYS,
+    "premium": TWO_BUSINESS_DAYS,
+    "custom": SPECIFICALLY_AGREED,
+    "not_sure": SPECIFICALLY_AGREED,
+}
+
+TURNAROUND_LABELS = {
+    NEXT_BUSINESS_DAY: "Next-business-day delivery",
+    TWO_BUSINESS_DAYS: "Delivery within 2 business days",
+    SPECIFICALLY_AGREED: "Turnaround as specifically agreed",
+}
+
+TURNAROUND_DETAILS = {
+    NEXT_BUSINESS_DAY: (
+        "This package is normally delivered by the end of the next business day."
+    ),
+    TWO_BUSINESS_DAYS: (
+        "This package is normally delivered within two business days due to the "
+        "additional video-production workload."
+    ),
+    SPECIFICALLY_AGREED: (
+        "Turnaround will be set out in the specifically agreed quotation."
+    ),
+}
+
+TURNAROUND_CONTEXT = (
+    "Turnaround begins once the shoot is complete and all required property and "
+    "client information has been supplied. Weather-dependent return visits and "
+    "agreed changes to the scope may affect delivery."
+)
+
+
+def get_package_turnaround_code(package):
+    return PACKAGE_TURNAROUND_CODES.get(str(package or ""), SPECIFICALLY_AGREED)
+
+
+def get_package_turnaround_label(package):
+    return TURNAROUND_LABELS[get_package_turnaround_code(package)]
+
+
+def get_package_turnaround_detail(package):
+    return TURNAROUND_DETAILS[get_package_turnaround_code(package)]

--- a/realestate/views.py
+++ b/realestate/views.py
@@ -58,7 +58,15 @@ class RealEstateEnquiryCreateView(generics.CreateAPIView):
         notes = []
         if self.enquiry.preferred_package:
             notes.append(
-                f"Preferred package: {self.enquiry.get_preferred_package_display()}"
+                f"Preferred package: {self.enquiry.get_preferred_package_summary()}"
+            )
+            notes.append(
+                "Included edited photographs: "
+                f"{self.enquiry.get_included_photographs_label()}"
+            )
+            notes.append(
+                "Standard turnaround: "
+                f"{self.enquiry.get_preferred_package_turnaround_label()}"
             )
         if self.enquiry.property_address:
             notes.append(f"Property address: {self.enquiry.property_address}")
@@ -103,6 +111,19 @@ class RealEstateEnquiryCreateView(generics.CreateAPIView):
                 "id": self.enquiry.id,
                 "status": self.enquiry.status,
                 "message": "Enquiry received successfully.",
+                "package_summary": self.enquiry.get_preferred_package_summary(),
+                "included_photograph_count": (
+                    self.enquiry.get_included_photograph_count()
+                ),
+                "included_photographs_label": (
+                    self.enquiry.get_included_photographs_label()
+                ),
+                "turnaround_code": (
+                    self.enquiry.get_preferred_package_turnaround_code()
+                ),
+                "turnaround_label": (
+                    self.enquiry.get_preferred_package_turnaround_label()
+                ),
             },
             status=status.HTTP_201_CREATED,
         )

--- a/templates/admin/realestate/enquiry/operations_hub.html
+++ b/templates/admin/realestate/enquiry/operations_hub.html
@@ -108,6 +108,7 @@
         <dt>Status</dt><dd><span class="re-ops-badge">{{ hub.booking.status }}</span></dd>
         <dt>Shoot</dt><dd>{{ hub.booking.shoot }}</dd>
         <dt>Package</dt><dd>{{ hub.booking.package }}</dd>
+        <dt>Standard turnaround</dt><dd>{{ hub.booking.turnaround }}</dd>
         <dt>Arrangement</dt><dd>{{ hub.booking.arrangement }}</dd>
         <dt>Expected method</dt><dd>{{ hub.booking.expected_method }}</dd>
         <dt>Agreement</dt><dd>{{ hub.booking.agreement }}</dd>

--- a/templates/emails/real_estate/booking_agreement.html
+++ b/templates/emails/real_estate/booking_agreement.html
@@ -16,7 +16,11 @@
     <p style="margin:0 0 8px; color:#5F6673; font-size:12px; letter-spacing:.12em; text-transform:uppercase;">Booking details</p>
     <p style="margin:0 0 6px;"><strong>Reference:</strong> {{ booking_reference|default:"To be confirmed" }}</p>
     <p style="margin:0 0 6px;"><strong>Property:</strong> {{ property_address|default:"Not specified" }}</p>
+    <p style="margin:0 0 6px;"><strong>Package:</strong> {{ package_name|default:"Not specified" }}</p>
+    {% if included_photographs_label %}<p style="margin:0 0 6px;"><strong>Included edited photographs:</strong> {{ included_photographs_label }}</p>{% endif %}
+    <p style="margin:0 0 6px; color:#5F6673; font-size:13px;">{{ additional_photograph_copy }}</p>
     <p style="margin:0 0 6px;"><strong>Proposed shoot:</strong> {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}</p>
+    {% if turnaround_label %}<p style="margin:0 0 6px;"><strong>Standard turnaround:</strong> {{ turnaround_label }}</p>{% endif %}
     <p style="margin:0 0 6px;"><strong>Package total:</strong> {{ total_required|default:"To be confirmed" }}</p>
     <p style="margin:0 0 6px;"><strong>Payment arrangement:</strong> {{ payment_arrangement_label|default:"To be confirmed" }}</p>
     {% if is_deposit_then_balance %}

--- a/templates/emails/real_estate/booking_agreement.txt
+++ b/templates/emails/real_estate/booking_agreement.txt
@@ -9,7 +9,12 @@ Thanks again for confirming you would like to proceed. Your booking agreement is
 Booking details
 Reference: {{ booking_reference|default:"To be confirmed" }}
 Property: {{ property_address|default:"Not specified" }}
+Package: {{ package_name|default:"Not specified" }}
+{% if included_photographs_label %}Included edited photographs: {{ included_photographs_label }}
+{% endif %}{{ additional_photograph_copy }}
 Proposed shoot: {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}
+{% if turnaround_label %}Standard turnaround: {{ turnaround_label }}
+{% endif %}
 Package total: {{ total_required|default:"To be confirmed" }}
 Payment arrangement: {{ payment_arrangement_label|default:"To be confirmed" }}
 {% if is_deposit_then_balance %}Deposit: {{ deposit_amount|default:"To be confirmed" }}

--- a/templates/emails/real_estate/confirmation.html
+++ b/templates/emails/real_estate/confirmation.html
@@ -13,10 +13,15 @@
     <p style="margin:0 0 6px;"><strong>Property:</strong> {{ property_address|default:"Not specified" }}</p>
     <p style="margin:0 0 6px;"><strong>Shoot date:</strong> {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}</p>
     <p style="margin:0 0 6px;"><strong>Package:</strong> {{ package_name|default:"Not specified" }}</p>
+    {% if included_photographs_label %}<p style="margin:0 0 6px;"><strong>Included edited photographs:</strong> {{ included_photographs_label }}</p>{% endif %}
+    <p style="margin:0 0 6px; color:#5F6673; font-size:13px;">{{ additional_photograph_copy }}</p>
+    {% if turnaround_label %}<p style="margin:0 0 6px;"><strong>Standard turnaround:</strong> {{ turnaround_label }}</p>{% endif %}
+    {% if turnaround_detail %}<p style="margin:0 0 6px; color:#5F6673; font-size:13px;">{{ turnaround_detail }}</p>{% endif %}
     <p style="margin:0 0 6px;"><strong>Payment arrangement:</strong> {{ payment_arrangement_label|default:"Not specified" }}</p>
     {% if is_full_on_shoot_day %}<p style="margin:0;"><strong>Payment due:</strong> {{ total_required }} on {{ payment_due_date }}{% if expected_payment_method %} by {{ expected_payment_method }}{% endif %}</p>{% endif %}
   </div>
 {% endblock %}
 {% block service_note %}
+  {% if turnaround_context %}<p style="margin:22px 0 0; color:#5F6673; font-size:13px; line-height:1.6;">{{ turnaround_context }}</p>{% endif %}
   <p style="margin:22px 0 0; color:#5F6673; font-size:13px; line-height:1.6;">If access arrangements, keys, alarms or vendor availability change before the shoot, please reply to this email as soon as possible.</p>
 {% endblock %}

--- a/templates/emails/real_estate/confirmation.txt
+++ b/templates/emails/real_estate/confirmation.txt
@@ -7,8 +7,15 @@ Reference: {{ booking_reference|default:"To be confirmed" }}
 Property: {{ property_address|default:"Not specified" }}
 Shoot date: {{ shoot_date|default:"Date TBC" }}{% if shoot_time %} at {{ shoot_time }}{% endif %}
 Package: {{ package_name|default:"Not specified" }}
+{% if included_photographs_label %}Included edited photographs: {{ included_photographs_label }}
+{% endif %}{{ additional_photograph_copy }}
+{% if turnaround_label %}Standard turnaround: {{ turnaround_label }}
+{% endif %}{% if turnaround_detail %}{{ turnaround_detail }}
+{% endif %}
 Payment arrangement: {{ payment_arrangement_label|default:"Not specified" }}
 {% if is_full_on_shoot_day %}Payment due: {{ total_required }} on {{ payment_due_date }}{% if expected_payment_method %} by {{ expected_payment_method }}{% endif %}
+{% endif %}
+{% if turnaround_context %}{{ turnaround_context }}
 {% endif %}
 If access arrangements, keys, alarms or vendor availability change before the shoot, please reply to this email as soon as possible.
 

--- a/templates/emails/real_estate/enquiry_reply.html
+++ b/templates/emails/real_estate/enquiry_reply.html
@@ -11,6 +11,9 @@
     <p style="margin:0 0 8px; color:#5F6673; font-size:12px; letter-spacing:.12em; text-transform:uppercase;">Request summary</p>
     <p style="margin:0 0 6px;"><strong>Property:</strong> {{ property_address|default:"Not specified" }}</p>
     <p style="margin:0 0 6px;"><strong>Package:</strong> {{ package_name|default:"Not specified" }}</p>
+    {% if included_photographs_label %}<p style="margin:0 0 6px;"><strong>Included edited photographs:</strong> {{ included_photographs_label }}</p>{% endif %}
+    <p style="margin:0 0 6px; color:#5F6673; font-size:13px;">{{ additional_photograph_copy }}</p>
+    {% if turnaround_label %}<p style="margin:0 0 6px;"><strong>Standard turnaround:</strong> {{ turnaround_label }}</p>{% endif %}
     <p style="margin:0;"><strong>Preferred date:</strong> {{ shoot_date|default:"Not specified" }}</p>
   </div>
 {% endblock %}

--- a/templates/emails/real_estate/enquiry_reply.txt
+++ b/templates/emails/real_estate/enquiry_reply.txt
@@ -5,6 +5,10 @@ Thanks for getting in touch with OpenÉire Studios. We have received your proper
 Request summary
 Property: {{ property_address|default:"Not specified" }}
 Package: {{ package_name|default:"Not specified" }}
+{% if included_photographs_label %}Included edited photographs: {{ included_photographs_label }}
+{% endif %}{{ additional_photograph_copy }}
+{% if turnaround_label %}Standard turnaround: {{ turnaround_label }}
+{% endif %}
 Preferred date: {{ shoot_date|default:"Not specified" }}
 
 We will come back to you within 24 hours with next steps. If anything changes in the meantime, simply reply to this email.

--- a/templates/emails/real_estate/quote.html
+++ b/templates/emails/real_estate/quote.html
@@ -11,6 +11,10 @@
     <p style="margin:0 0 8px; color:#5F6673; font-size:12px; letter-spacing:.12em; text-transform:uppercase;">Quote details</p>
     <p style="margin:0 0 6px;"><strong>Property:</strong> {{ property_address|default:"Not specified" }}</p>
     <p style="margin:0 0 6px;"><strong>Package:</strong> {{ package_name|default:"Not specified" }}</p>
+    {% if included_photographs_label %}<p style="margin:0 0 6px;"><strong>Included edited photographs:</strong> {{ included_photographs_label }}</p>{% endif %}
+    <p style="margin:0 0 6px; color:#5F6673; font-size:13px;">{{ additional_photograph_copy }}</p>
+    {% if turnaround_label %}<p style="margin:0 0 6px;"><strong>Standard turnaround:</strong> {{ turnaround_label }}</p>{% endif %}
+    {% if turnaround_detail %}<p style="margin:0 0 6px; color:#5F6673; font-size:13px;">{{ turnaround_detail }}</p>{% endif %}
     {% if addons %}<p style="margin:0 0 6px;"><strong>Add-ons:</strong> {% for addon in addons %}{{ addon }}{% if not forloop.last %}; {% endif %}{% endfor %}</p>{% endif %}
     {% if quote_total or vat_total or total_including_vat or deposit_amount or balance_due %}
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:16px; border-top:1px solid #E5E7EB;">
@@ -77,5 +81,6 @@
   </div>
 {% endblock %}
 {% block service_note %}
+  {% if turnaround_context %}<p style="margin:22px 0 0; color:#5F6673; font-size:13px; line-height:1.6;">{{ turnaround_context }}</p>{% endif %}
   <p style="margin:22px 0 0; color:#5F6673; font-size:13px; line-height:1.6;">This quote does not confirm a booking or reserve a shoot date.</p>
 {% endblock %}

--- a/templates/emails/real_estate/quote.txt
+++ b/templates/emails/real_estate/quote.txt
@@ -5,6 +5,11 @@ Thank you for sharing the details for {{ property_address|default:"the property"
 Quote details
 Property: {{ property_address|default:"Not specified" }}
 Package: {{ package_name|default:"Not specified" }}
+{% if included_photographs_label %}Included edited photographs: {{ included_photographs_label }}
+{% endif %}{{ additional_photograph_copy }}
+{% if turnaround_label %}Standard turnaround: {{ turnaround_label }}
+{% endif %}{% if turnaround_detail %}{{ turnaround_detail }}
+{% endif %}
 {% if addons %}Add-ons: {% for addon in addons %}{{ addon }}{% if not forloop.last %}; {% endif %}{% endfor %}
 {% endif %}{% if quote_total or vat_total or total_including_vat or deposit_amount or balance_due %}
 Quote summary
@@ -29,6 +34,8 @@ Ready to proceed?
 
 {% if quote_reply_email %}Proceed with this quote: {{ quote_reply_email }}
 {% else %}Reply details are being confirmed. Please contact studio@openeire.ie and quote this property address.
+{% endif %}
+{% if turnaround_context %}{{ turnaround_context }}
 {% endif %}
 This quote does not confirm a booking or reserve a shoot date.
 


### PR DESCRIPTION
## What changed

- preserves rollout compatibility for legacy real-estate submissions while keeping strict V2 validation
- centralizes package photograph allowances and package-aware turnaround metadata
- updates Starter, Pro, and Premium allowances for new work while protecting historical agreement scope
- introduces Booking Agreement template v1.8 via forward-only migrations 0022 and 0023
- updates API output, emails, admin operations, agreement content, financial documents, and rollout documentation

## Safety

- existing v1.6 and v1.7 agreement snapshots remain byte-for-byte unchanged
- snapshotted scope is preferred for historical workflows
- booked/completed records without recoverable scope fail closed for manual review
- no data migration or historical record rewrite

## Validation

- 511 backend tests passed
- Django system checks passed
- `makemigrations --check --dry-run` reported no drift
- `git diff --check` passed
- representative v1.8 Booking Agreement PDF visually reviewed