### PR TITLE
Fix blank portal delivery HTML email

### DIFF
--- a/realestate/delivery_emails.py
+++ b/realestate/delivery_emails.py
@@ -49,10 +49,13 @@ def send_delivery_recipient_email(recipient, *, kind, idempotency_key, actor=Non
         )
         return attempt
     delivery = recipient.delivery
+    delivery_url = build_recipient_url(recipient)
     context = {
         "first_name": recipient.display_name.split()[0] or "there",
         "delivery_title": delivery.public_title,
-        "delivery_url": build_recipient_url(recipient),
+        "delivery_url": delivery_url,
+        "cta_url": delivery_url,
+        "cta_label": "Open private delivery",
         "expires_at": delivery.expires_at,
         "access_days": max(
             1, (delivery.expires_at.date() - timezone.localdate()).days

--- a/realestate/test_delivery_portal.py
+++ b/realestate/test_delivery_portal.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 from decimal import Decimal
+from html.parser import HTMLParser
 from unittest.mock import patch
 
+from django.core import mail
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.core.cache import caches
@@ -17,6 +19,7 @@ from checkout.views import StripeWebhookView
 from .delivery import (
     DOWNLOAD_URL_SECONDS,
     activate_delivery,
+    build_recipient_url,
     build_staff_preview_url,
     delivery_dto,
     evaluate_delivery_access,
@@ -52,6 +55,18 @@ from .delivery_views import DeliveryScopedRateThrottle
 TOKEN_KEY = "token-key-with-high-entropy-1234567890-ABCDEFGHI"
 SESSION_KEY = "session-key-with-high-entropy-0987654321-ZYXWV"
 INTERNAL_KEY = "internal-key-with-high-entropy-1357902468-QWERTY"
+
+
+class AnchorHrefParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.hrefs = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "a":
+            href = dict(attrs).get("href")
+            if href:
+                self.hrefs.append(href)
 
 
 @override_settings(
@@ -988,6 +1003,52 @@ class DeliveryPortalTestCase(TestCase):
         ).latest("created_at")
         self.assertEqual(timeline.reference_url, "")
         self.assertNotIn(link, timeline.notes)
+        self.assertNotIn(link.partition("#")[2], timeline.notes)
+
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+    def test_portal_email_renders_complete_html_and_text_content(self):
+        mail.outbox = []
+        self.delivery.download_instructions = "Download each file before expiry."
+        self.delivery.licence_summary = "Use is licensed for this property listing."
+        self.delivery.save(
+            update_fields=("download_instructions", "licence_summary", "updated_at")
+        )
+        delivery_url = build_recipient_url(self.recipient)
+
+        attempt = send_delivery_recipient_email(
+            self.recipient,
+            kind=RealEstateDeliveryEmailAttempt.Kind.INITIAL,
+            idempotency_key="fictional-rendered-email",
+            actor=self.user,
+        )
+
+        attempt.refresh_from_db()
+        self.assertEqual(attempt.status, RealEstateDeliveryEmailAttempt.Status.SENT)
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertEqual(email.subject, "Your private media delivery is ready")
+        self.assertEqual(len(email.alternatives), 1)
+        html_body, mime_type = email.alternatives[0]
+        self.assertEqual(mime_type, "text/html")
+
+        parser = AnchorHrefParser()
+        parser.feed(html_body)
+        self.assertIn("Hi Fictional,", html_body)
+        self.assertIn(self.delivery.public_title, html_body)
+        self.assertIn("Your private media delivery is ready", html_body)
+        self.assertIn("Open private delivery", html_body)
+        self.assertIn(delivery_url, parser.hrefs)
+        self.assertIn("Download each file before expiry.", html_body)
+        self.assertIn("Use is licensed for this property listing.", html_body)
+        self.assertIn(delivery_url, email.body)
+
+        timeline = RealEstateTimelineEvent.objects.get(
+            event_type=RealEstateTimelineEvent.EventType.DELIVERY_SENT
+        )
+        secret = delivery_url.partition("#")[2]
+        self.assertNotIn(delivery_url, timeline.notes)
+        self.assertNotIn(secret, timeline.notes)
+        self.assertEqual(timeline.reference_url, "")
 
     @patch(
         "realestate.delivery_emails.record_timeline_event",

--- a/templates/emails/real_estate/portal_delivery.html
+++ b/templates/emails/real_estate/portal_delivery.html
@@ -1,14 +1,12 @@
 {% extends "emails/base_email.html" %}
 
-{% block content %}
+{% block title %}Your private media delivery is ready{% endblock %}
+{% block preheader %}Your private media delivery is ready to open.{% endblock %}
+{% block heading %}Your private media delivery is ready{% endblock %}
+{% block body %}
   <p>Hi {{ first_name }},</p>
   <p>Your private OpenÉire Studios media delivery is ready.</p>
-  <h2>{{ delivery_title }}</h2>
-  <p>
-    <a href="{{ delivery_url }}" style="display:inline-block;padding:12px 20px;background:#ffc400;color:#111;text-decoration:none;font-weight:700;">
-      Open private delivery
-    </a>
-  </p>
+  <p><strong>{{ delivery_title }}</strong></p>
   <p>Access is currently available for {{ access_days }} day{{ access_days|pluralize }}.</p>
   {% if download_instructions %}<p><strong>Download instructions:</strong><br>{{ download_instructions|linebreaksbr }}</p>{% endif %}
   {% if licence_summary %}<p><strong>Licence / use summary:</strong><br>{{ licence_summary|linebreaksbr }}</p>{% endif %}


### PR DESCRIPTION
## Summary

- replace the unused `content` block in the portal delivery HTML email with the established base-email blocks
- render the heading, greeting, privacy-safe title, access duration, optional instructions/licence summary, and personal-link warning
- pass the complete recipient URL through the shared `cta_url`/`cta_label` pattern
- preserve the complete fragment-bearing URL in both HTML and plain text
- add end-to-end email rendering, sending, and audit-redaction regression coverage

## Root cause

`templates/emails/real_estate/portal_delivery.html` extended `emails/base_email.html` but defined a `content` block. The base template never renders that block; it renders `heading`, `body`, `details_card`, `cta`, and `service_note`. Django therefore discarded the portal email's entire child body without raising an error.

## Security and behavior

The generated recipient link remains deterministic and is built once per send. The full fragment credential is present only in the intended HTML CTA and text alternative. Timeline records continue to contain only the recipient public ID and masked email; regression tests assert that neither the complete URL nor fragment credential appears in timeline notes or reference URLs.

Subjects, reply-to behavior, branding, email-attempt auditing, and ordinary delivery access policy are unchanged. No MyAirBridge dependency or fallback was introduced.

The other real-estate child templates were audited against `base_email.html`; no other incompatible block names remain.

## Checks

- focused email and delivery tests: 65 passed
- complete backend suite: 556 passed
- Django system check with portal flag disabled: passed
- Django system check with portal flag enabled: passed
- `makemigrations --check --dry-run`: no changes detected
- template block compatibility audit: passed
- `git diff --check`: passed

No frontend, R2, Render variable, production data, or migration changes are included.