### PR TITLE
Add production-safe delivery ZIP support

### DIFF
--- a/docs/real-estate-delivery-portal.md
+++ b/docs/real-estate-delivery-portal.md
@@ -49,7 +49,7 @@ Backend:
 - `REAL_ESTATE_DELIVERY_R2_PREFIX=real-estate-deliveries`
 - `REAL_ESTATE_DELIVERY_MAX_FILE_SIZE=53687091200`
 - `REAL_ESTATE_DELIVERY_MAX_FILES=100`
-- `REAL_ESTATE_DELIVERY_ALLOWED_MIME_TYPES=application/zip,image/jpeg,image/webp,video/mp4,application/pdf`
+- `REAL_ESTATE_DELIVERY_ALLOWED_MIME_TYPES=application/zip,application/x-zip-compressed,image/jpeg,image/webp,video/mp4,application/pdf`
 - Existing private R2 variables: `R2_ENDPOINT_URL`,
   `R2_PRIVATE_BUCKET_NAME`, `R2_PRIVATE_ACCESS_KEY_ID` and
   `R2_PRIVATE_SECRET_ACCESS_KEY`.
@@ -112,7 +112,10 @@ backup strategy.
    payer or other roles. Payment does not grant recipient access.
 4. Review the existing finance panel. Resolve missing final/full invoices,
    partial payments, refunds/disputes or use the existing reasoned override.
-5. Open **Upload media**. Choose a client-safe display name and category. The
+5. Open **Upload media**. Choose a client-safe display name and category. JPG,
+   WebP, MP4, PDF and ZIP files are supported. Use **Photographs** for a
+   complete property photograph package ZIP; **ZIP / archive** remains
+   available for other intentional archives. The
    browser uploads parts directly to private R2, with no more than the
    server-provided number of concurrent part requests. Keep the page open
    through final verification. Uploads do not resume across a refresh or
@@ -136,8 +139,29 @@ Until the rollout is accepted, the existing `delivery_provider` and
 `delivery_link` fields remain the MyAirBridge workflow. Historical records and
 templates are unchanged. Use the existing MyAirBridge action as fallback.
 
-The MVP does not automate ZIP creation. Prepare ZIP files locally, scan/check
-them, and upload them manually.
+The MVP does not automate ZIP creation. ZIP archives are delivered exactly as
+uploaded and Django/Next never extract, inspect, transform or generate them.
+Prepare and check archives locally before uploading them. The configured
+maximum is 50 GiB per file (approximately 50 GB as displayed by the admin), so
+the expected approximately 1 GiB photograph packages fit without a limit
+change.
+
+ZIP validation is deliberately narrower than the general MIME policy:
+
+- the final case-insensitive filename extension must be `.zip`;
+- `application/zip` and `application/x-zip-compressed` are accepted;
+- an empty browser MIME or `application/octet-stream` is accepted only for a
+  final `.zip` filename in the **Photographs** or **ZIP / archive** category;
+- `application/octet-stream` is never a general delivery-file allowance;
+- a ZIP MIME with `.exe` or another final extension is rejected;
+- names such as `client-export.exe.zip` are accepted because only the final
+  safe extension determines the filename policy. This does not inspect or make
+  claims about archive contents;
+- accepted archives are stored and verified as canonical `application/zip`.
+
+Windows browsers commonly report `application/x-zip-compressed`, an empty MIME
+or `application/octet-stream` for ZIP files. These values use the constrained
+ZIP path above and do not broaden uploads for other file types.
 
 ## Finance and reversals
 
@@ -228,6 +252,8 @@ Common failures:
 - Payment locked: inspect all issued final/full invoices, successful payments,
   reversal metadata and overrides.
 - Upload missing `ETag`: expose `ETag` in private-bucket CORS.
+- Unsupported ZIP: confirm the final `.zip` extension, Photographs or ZIP /
+  archive category, and one of the supported Windows MIME behaviours above.
 - Upload verification failed: compare expected size/MIME with R2 `HeadObject`;
   do not manually activate the object.
 - Download generation failed: verify private R2 credentials/bucket and current

--- a/openeire_api/settings.py
+++ b/openeire_api/settings.py
@@ -123,7 +123,10 @@ REAL_ESTATE_DELIVERY_MAX_FILES = _safe_int_env(
 )
 REAL_ESTATE_DELIVERY_ALLOWED_MIME_TYPES = os.getenv(
     "REAL_ESTATE_DELIVERY_ALLOWED_MIME_TYPES",
-    "application/zip,image/jpeg,image/webp,video/mp4,application/pdf",
+    (
+        "application/zip,application/x-zip-compressed,image/jpeg,image/webp,"
+        "video/mp4,application/pdf"
+    ),
 )
 
 if REAL_ESTATE_DELIVERY_PORTAL_ENABLED and not IS_TEST_ENV:

--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -42,6 +42,7 @@ from .delivery import (
     rotate_recipient_secret,
 )
 from .delivery_emails import send_delivery_recipient_email
+from .delivery_storage import get_max_size
 from .finance import can_release_realestate_delivery, create_realestate_balance_checkout_session, ensure_invoices_for_arrangement, record_realestate_payment, revoke_delivery_override, void_local_realestate_invoice
 from .stripe_invoices import create_stripe_invoice, mark_stripe_invoice_paid_out_of_band, send_stripe_invoice
 from .payments import calculate_realestate_deposit_amounts
@@ -2196,6 +2197,7 @@ class RealEstateDeliveryAdmin(admin.ModelAdmin):
                 "title": "Upload delivery media",
                 "delivery": delivery,
                 "categories": RealEstateDeliverable.Category.choices,
+                "max_file_size": get_max_size(),
             },
         )
 

--- a/realestate/delivery.py
+++ b/realestate/delivery.py
@@ -314,6 +314,9 @@ def delivery_dto(recipient):
                 "filename": item.original_filename,
                 "size": item.file_size,
                 "mime_type": item.mime_type,
+                "format_label": (
+                    "ZIP archive" if item.mime_type == "application/zip" else ""
+                ),
             }
         )
     delivery = recipient.delivery
@@ -359,6 +362,9 @@ def delivery_preview_dto(delivery):
                 "filename": item.original_filename,
                 "size": item.file_size,
                 "mime_type": item.mime_type,
+                "format_label": (
+                    "ZIP archive" if item.mime_type == "application/zip" else ""
+                ),
             }
         )
     return {

--- a/realestate/delivery_serializers.py
+++ b/realestate/delivery_serializers.py
@@ -26,13 +26,20 @@ class DeliveryUploadStartSerializer(serializers.Serializer):
     filename = serializers.CharField(max_length=255)
     display_name = serializers.CharField(max_length=255)
     category = serializers.ChoiceField(choices=RealEstateDeliverable.Category.choices)
-    content_type = serializers.CharField(max_length=100)
+    content_type = serializers.CharField(max_length=100, allow_blank=True)
     file_size = serializers.IntegerField(min_value=1, max_value=get_max_size())
     sort_order = serializers.IntegerField(min_value=0, default=0)
     replaces_id = serializers.UUIDField(required=False, allow_null=True)
 
     def validate(self, attrs):
-        validate_upload(attrs["filename"], attrs["content_type"], attrs["file_size"])
+        safe_name, canonical_type = validate_upload(
+            attrs["filename"],
+            attrs["content_type"],
+            attrs["file_size"],
+            attrs["category"],
+        )
+        attrs["filename"] = safe_name
+        attrs["content_type"] = canonical_type
         delivery = RealEstateDelivery.objects.filter(pk=attrs["delivery_id"]).first()
         if not delivery:
             raise serializers.ValidationError("Selected delivery does not exist.")

--- a/realestate/delivery_storage.py
+++ b/realestate/delivery_storage.py
@@ -16,10 +16,15 @@ DELIVERY_PREFIX = "real-estate-deliveries"
 ALLOWED_TYPES = {
     "application/pdf",
     "application/zip",
+    "application/x-zip-compressed",
     "image/jpeg",
     "image/webp",
     "video/mp4",
 }
+CANONICAL_ZIP_TYPE = "application/zip"
+ZIP_MIME_TYPES = {CANONICAL_ZIP_TYPE, "application/x-zip-compressed"}
+ZIP_FALLBACK_MIME_TYPES = {"", "application/octet-stream"}
+ZIP_CATEGORIES = {"photographs", "archive"}
 GENERATED_OBJECT_NAME_RE = re.compile(r"^[0-9a-f]{32}(?:\.[A-Za-z0-9]{1,10})?$")
 
 
@@ -62,13 +67,28 @@ def _validated_prefix():
     return prefix
 
 
-def validate_upload(filename, content_type, file_size):
+def validate_upload(filename, content_type, file_size, category):
+    safe_name = safe_download_filename(filename)
     normalized_type = str(content_type or "").strip().lower()
-    if normalized_type not in get_allowed_types():
+    allowed_types = get_allowed_types()
+    is_zip = Path(safe_name).suffix.lower() == ".zip"
+    zip_policy_enabled = bool(allowed_types.intersection(ZIP_MIME_TYPES))
+
+    if is_zip:
+        if (
+            str(category or "") not in ZIP_CATEGORIES
+            or normalized_type not in ZIP_MIME_TYPES | ZIP_FALLBACK_MIME_TYPES
+            or not zip_policy_enabled
+        ):
+            raise ValidationError("Unsupported delivery file type.")
+        normalized_type = CANONICAL_ZIP_TYPE
+    elif normalized_type in ZIP_MIME_TYPES:
+        raise ValidationError("Unsupported delivery file type.")
+    elif normalized_type not in allowed_types:
         raise ValidationError("Unsupported delivery file type.")
     if int(file_size) <= 0 or int(file_size) > get_max_size():
         raise ValidationError("Delivery file size is outside the allowed range.")
-    return safe_download_filename(filename), normalized_type
+    return safe_name, normalized_type
 
 
 def delivery_object_key(delivery, filename):
@@ -100,8 +120,10 @@ def _bucket():
     return settings.R2_PRIVATE_BUCKET_NAME
 
 
-def start_upload(delivery, filename, content_type, file_size):
-    safe_name, normalized_type = validate_upload(filename, content_type, file_size)
+def start_upload(delivery, filename, content_type, file_size, category):
+    safe_name, normalized_type = validate_upload(
+        filename, content_type, file_size, category
+    )
     object_key = delivery_object_key(delivery, safe_name)
     response = _client().create_multipart_upload(
         Bucket=_bucket(),

--- a/realestate/delivery_views.py
+++ b/realestate/delivery_views.py
@@ -287,7 +287,11 @@ class StaffDeliveryUploadStartView(StaffDeliveryUploadView):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         upload_id, object_key, part_size, filename, mime_type = start_upload(
-            data["delivery"], data["filename"], data["content_type"], data["file_size"]
+            data["delivery"],
+            data["filename"],
+            data["content_type"],
+            data["file_size"],
+            data["category"],
         )
         try:
             session = RealEstateDeliveryUploadSession.objects.create(

--- a/realestate/js_tests/delivery_multipart_uploader.test.mjs
+++ b/realestate/js_tests/delivery_multipart_uploader.test.mjs
@@ -8,6 +8,7 @@ import {
   createDeliveryUploadApi,
   DeliveryUploadCancelledError,
   DeliveryUploadError,
+  getDeliveryUploadContentType,
   uploadPartWithXhr,
 } from "../static/realestate/js/delivery_multipart_uploader.mjs";
 
@@ -38,6 +39,76 @@ const deferred = () => {
   });
   return { promise, resolve };
 };
+
+test("canonicalizes only constrained ZIP browser MIME fallbacks", () => {
+  const zip = (name, type) => ({ name, type });
+  assert.equal(
+    getDeliveryUploadContentType(zip("package.zip", "application/zip"), "photographs"),
+    "application/zip",
+  );
+  assert.equal(
+    getDeliveryUploadContentType(
+      zip("package.ZIP", "application/x-zip-compressed"),
+      "photographs",
+    ),
+    "application/zip",
+  );
+  assert.equal(
+    getDeliveryUploadContentType(
+      zip("windows.zip", "application/octet-stream"),
+      "archive",
+    ),
+    "application/zip",
+  );
+  assert.equal(
+    getDeliveryUploadContentType(zip("empty.zip", ""), "photographs"),
+    "application/zip",
+  );
+  assert.equal(
+    getDeliveryUploadContentType(
+      zip("photograph.jpg", "application/octet-stream"),
+      "photographs",
+    ),
+    "application/octet-stream",
+  );
+  assert.equal(
+    getDeliveryUploadContentType(
+      zip("wrong-category.zip", "application/octet-stream"),
+      "main_video",
+    ),
+    "application/octet-stream",
+  );
+});
+
+test("uses the canonical start MIME for every ZIP part", async () => {
+  const file = makeFile(25, "application/x-zip-compressed");
+  file.name = "complete-package.ZIP";
+  const { api } = makeApi({ partSize: 10 });
+  const observedTypes = [];
+  const task = createDeliveryMultipartUpload({
+    api,
+    file,
+    startPayload: {
+      delivery_id: 17,
+      filename: file.name,
+      display_name: "Complete photograph package",
+      category: "photographs",
+      content_type: getDeliveryUploadContentType(file, "photographs"),
+      file_size: file.size,
+    },
+    uploadPart: async ({ blob, contentType, url }) => {
+      observedTypes.push([blob.type, contentType]);
+      return { etag: `etag-${partNumberFromUrl(url)}` };
+    },
+  });
+
+  await task.promise;
+  assert.deepEqual(observedTypes, [
+    ["application/zip", "application/zip"],
+    ["application/zip", "application/zip"],
+    ["application/zip", "application/zip"],
+  ]);
+});
 
 const makeApi = ({
   maxConcurrency = 4,

--- a/realestate/static/realestate/js/delivery_multipart_uploader.mjs
+++ b/realestate/static/realestate/js/delivery_multipart_uploader.mjs
@@ -1,5 +1,26 @@
 const DEFAULT_RETRY_LIMIT = 3;
 const CANCELLED_MESSAGE = "Upload cancelled.";
+const CANONICAL_ZIP_TYPE = "application/zip";
+const ZIP_MIME_TYPES = new Set([
+  CANONICAL_ZIP_TYPE,
+  "application/x-zip-compressed",
+  "application/octet-stream",
+  "",
+]);
+const ZIP_CATEGORIES = new Set(["photographs", "archive"]);
+
+export const getDeliveryUploadContentType = (file, category) => {
+  const filename = String(file?.name || "");
+  const browserType = String(file?.type || "").trim().toLowerCase();
+  if (
+    /\.zip$/i.test(filename) &&
+    ZIP_CATEGORIES.has(String(category || "")) &&
+    ZIP_MIME_TYPES.has(browserType)
+  ) {
+    return CANONICAL_ZIP_TYPE;
+  }
+  return browserType || "application/octet-stream";
+};
 
 export class DeliveryUploadCancelledError extends Error {
   constructor(message = CANCELLED_MESSAGE) {
@@ -37,7 +58,7 @@ const safeBackendDetail = (detail, fallback) => {
 
 const phaseFallback = {
   start:
-    "Could not start the upload. Check the file type, size and delivery permissions.",
+    "Could not start the upload. Accepted delivery formats are JPG, WebP, MP4, PDF and ZIP.",
   "part-url":
     "Could not authorise an upload part. The upload session may have expired.",
   complete:
@@ -249,6 +270,10 @@ export const createDeliveryMultipartUpload = ({
   if (!file || !Number.isFinite(file.size) || file.size <= 0) {
     throw new Error("A non-empty file is required.");
   }
+  const uploadContentType =
+    String(startPayload?.content_type || "").trim().toLowerCase() ||
+    String(file.type || "").trim().toLowerCase() ||
+    "application/octet-stream";
 
   const abortController = new AbortController();
   let startedUpload = null;
@@ -324,7 +349,7 @@ export const createDeliveryMultipartUpload = ({
         const blob = file.slice(
           start,
           end,
-          file.type || "application/octet-stream",
+          uploadContentType,
         );
         let lastError = null;
 
@@ -356,7 +381,7 @@ export const createDeliveryMultipartUpload = ({
             }
             const result = await uploadPart({
               blob,
-              contentType: file.type || "application/octet-stream",
+              contentType: uploadContentType,
               onProgress: (loadedBytes) => {
                 partProgress.set(
                   partNumber,

--- a/realestate/test_delivery_portal.py
+++ b/realestate/test_delivery_portal.py
@@ -30,12 +30,15 @@ from .delivery import (
     revoke_recipient_access,
     rotate_recipient_secret,
 )
+from .delivery_serializers import DeliveryUploadStartSerializer
 from .delivery_emails import send_delivery_recipient_email
 from .delivery_storage import (
     complete_upload,
     delete_validated_object,
     delivery_object_key,
     download_url,
+    start_upload,
+    validate_upload,
 )
 from .models import (
     RealEstateDeliverable,
@@ -398,6 +401,10 @@ class DeliveryPortalTestCase(TestCase):
         payload = delivery_dto(loaded)
         self.assertEqual(payload["state"], "valid")
         self.assertNotIn("object_key", str(payload))
+        delivered_file = payload["delivery"]["groups"][0]["files"][0]
+        self.assertEqual(delivered_file["mime_type"], "application/zip")
+        self.assertEqual(delivered_file["format_label"], "ZIP archive")
+        self.assertEqual(delivered_file["display_name"], "Web photographs")
         self.assertIn(str(self.file.public_id), str(payload))
 
     def test_access_rechecks_payment_revocation_expiry_and_shoot(self):
@@ -800,6 +807,156 @@ class DeliveryPortalTestCase(TestCase):
         self.assertEqual(session.created_by, self.user)
         self.assertEqual(session.delivery, self.delivery)
 
+    @override_settings(
+        REAL_ESTATE_DELIVERY_ALLOWED_MIME_TYPES=(
+            "application/zip,image/jpeg,image/webp,video/mp4,application/pdf"
+        )
+    )
+    def test_zip_upload_validation_canonicalizes_supported_browser_variants(self):
+        cases = (
+            ("complete-package.zip", "application/zip"),
+            ("complete-package.ZIP", "application/x-zip-compressed"),
+            ("windows-package.zip", "application/octet-stream"),
+            ("empty-browser-type.zip", ""),
+            ("client-export.exe.zip", "application/zip"),
+        )
+        for filename, content_type in cases:
+            with self.subTest(filename=filename, content_type=content_type):
+                serializer = DeliveryUploadStartSerializer(
+                    data={
+                        "delivery_id": self.delivery.pk,
+                        "filename": filename,
+                        "display_name": "Complete photograph package",
+                        "category": RealEstateDeliverable.Category.PHOTOGRAPHS,
+                        "content_type": content_type,
+                        "file_size": 1024,
+                    }
+                )
+                self.assertTrue(serializer.is_valid(), serializer.errors)
+                self.assertEqual(
+                    serializer.validated_data["content_type"], "application/zip"
+                )
+                self.assertTrue(
+                    serializer.validated_data["filename"].lower().endswith(".zip")
+                )
+
+    def test_zip_validation_rejects_wrong_extensions_categories_and_generic_octet(self):
+        cases = (
+            (
+                "malware.exe",
+                "application/zip",
+                RealEstateDeliverable.Category.PHOTOGRAPHS,
+            ),
+            (
+                "notes.txt",
+                "application/x-zip-compressed",
+                RealEstateDeliverable.Category.ARCHIVE,
+            ),
+            (
+                "photograph.jpg",
+                "application/octet-stream",
+                RealEstateDeliverable.Category.PHOTOGRAPHS,
+            ),
+            (
+                "video.zip",
+                "application/zip",
+                RealEstateDeliverable.Category.MAIN_VIDEO,
+            ),
+            (
+                "wrong-type.zip",
+                "image/jpeg",
+                RealEstateDeliverable.Category.PHOTOGRAPHS,
+            ),
+        )
+        for filename, content_type, category in cases:
+            with self.subTest(filename=filename, content_type=content_type, category=category):
+                serializer = DeliveryUploadStartSerializer(
+                    data={
+                        "delivery_id": self.delivery.pk,
+                        "filename": filename,
+                        "display_name": "Rejected upload",
+                        "category": category,
+                        "content_type": content_type,
+                        "file_size": 1024,
+                    }
+                )
+                self.assertFalse(serializer.is_valid())
+                self.assertEqual(
+                    serializer.errors["non_field_errors"][0],
+                    "Unsupported delivery file type.",
+                )
+
+    @override_settings(REAL_ESTATE_DELIVERY_ALLOWED_MIME_TYPES="image/jpeg")
+    def test_zip_specific_path_still_respects_environment_mime_policy(self):
+        with self.assertRaisesMessage(
+            ValidationError, "Unsupported delivery file type."
+        ):
+            validate_upload(
+                "package.zip",
+                "application/octet-stream",
+                1024,
+                RealEstateDeliverable.Category.PHOTOGRAPHS,
+            )
+
+    def test_existing_delivery_mime_types_remain_supported(self):
+        cases = (
+            ("photograph.jpg", "image/jpeg", RealEstateDeliverable.Category.PHOTOGRAPHS),
+            ("photograph.webp", "image/webp", RealEstateDeliverable.Category.PHOTOGRAPHS),
+            ("property.mp4", "video/mp4", RealEstateDeliverable.Category.MAIN_VIDEO),
+            ("floor-plan.pdf", "application/pdf", RealEstateDeliverable.Category.FLOOR_PLAN),
+        )
+        for filename, content_type, category in cases:
+            with self.subTest(filename=filename, content_type=content_type):
+                safe_name, canonical_type = validate_upload(
+                    filename, content_type, 1024, category
+                )
+                self.assertEqual(safe_name, filename)
+                self.assertEqual(canonical_type, content_type)
+
+    @patch("realestate.delivery_storage._client")
+    def test_zip_multipart_initiation_uses_canonical_type_and_private_key(
+        self, client_factory
+    ):
+        client_factory.return_value.create_multipart_upload.return_value = {
+            "UploadId": "zip-upload-id"
+        }
+        result = start_upload(
+            self.delivery,
+            "complete-package.ZIP",
+            "application/x-zip-compressed",
+            1024 * 1024 * 1024,
+            RealEstateDeliverable.Category.PHOTOGRAPHS,
+        )
+
+        upload_id, object_key, part_size, filename, content_type = result
+        self.assertEqual(upload_id, "zip-upload-id")
+        self.assertTrue(object_key.endswith(".zip"))
+        self.assertNotIn("complete-package", object_key)
+        self.assertGreaterEqual(part_size, 10 * 1024 * 1024)
+        self.assertEqual(filename, "complete-package.ZIP")
+        self.assertEqual(content_type, "application/zip")
+        call = client_factory.return_value.create_multipart_upload.call_args.kwargs
+        self.assertEqual(call["ContentType"], "application/zip")
+        self.assertEqual(call["Metadata"], {"filename": "complete-package.ZIP"})
+
+    def test_admin_uploader_lists_zip_support_and_safe_accept_rules(self):
+        client = self.client
+        client.force_login(self.user)
+        response = client.get(
+            reverse(
+                "customadmin:realestate_realestatedelivery_uploads",
+                args=(self.delivery.pk,),
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "Accepted formats: JPG, WebP, MP4, PDF and ZIP"
+        )
+        self.assertContains(response, "application/zip")
+        self.assertContains(response, "application/x-zip-compressed")
+        self.assertContains(response, ".zip")
+
     @patch("realestate.delivery_views.start_upload")
     def test_staff_upload_start_requires_delivery_change_permission(self, start):
         staff_without_permission = get_user_model().objects.create_user(
@@ -878,11 +1035,22 @@ class DeliveryPortalTestCase(TestCase):
         storage_client.generate_presigned_url.return_value = (
             "https://r2.example.test/signed"
         )
+        self.file.original_filename = "../../fictional-photos.zip"
         self.assertEqual(download_url(self.file), "https://r2.example.test/signed")
         self.assertEqual(
             storage_client.generate_presigned_url.call_args.kwargs["ExpiresIn"],
             DOWNLOAD_URL_SECONDS,
         )
+        download_params = storage_client.generate_presigned_url.call_args.kwargs[
+            "Params"
+        ]
+        self.assertEqual(download_params["ResponseContentType"], "application/zip")
+        self.assertIn("attachment;", download_params["ResponseContentDisposition"])
+        self.assertIn(
+            "fictional-photos.zip", download_params["ResponseContentDisposition"]
+        )
+        self.assertNotIn("..", download_params["ResponseContentDisposition"])
+        self.assertNotIn("/", download_params["ResponseContentDisposition"])
 
     @patch("realestate.delivery_storage._client")
     def test_multipart_completion_rejects_missing_or_duplicate_parts(

--- a/templates/admin/realestate/delivery/uploads.html
+++ b/templates/admin/realestate/delivery/uploads.html
@@ -13,7 +13,17 @@
     {% csrf_token %}
     <div class="form-row">
       <label for="delivery-file">File</label>
-      <input id="delivery-file" type="file" required>
+      <input
+        id="delivery-file"
+        type="file"
+        accept=".jpg,.jpeg,.webp,.mp4,.pdf,.zip,image/jpeg,image/webp,video/mp4,application/pdf,application/zip,application/x-zip-compressed"
+        aria-describedby="delivery-file-help"
+        required
+      >
+      <p id="delivery-file-help" class="help">
+        Accepted formats: JPG, WebP, MP4, PDF and ZIP. Use Photographs for a
+        complete photograph package ZIP. Maximum size: {{ max_file_size|filesizeformat }}.
+      </p>
     </div>
     <div class="form-row">
       <label for="delivery-display-name">Client-safe display name</label>
@@ -39,6 +49,7 @@
       createDeliveryUploadApi,
       DeliveryUploadCancelledError,
       formatUploadBytes,
+      getDeliveryUploadContentType,
       getDeliveryUploadErrorMessage,
     } from "{% static 'realestate/js/delivery_multipart_uploader.mjs' %}";
 
@@ -82,6 +93,7 @@
       if (activeTask) return;
       const file = fileInput.files && fileInput.files[0];
       if (!file) return;
+      const category = categoryInput.value;
 
       finalising = false;
       setControlsDisabled(true);
@@ -96,8 +108,8 @@
           delivery_id: {{ delivery.pk }},
           filename: file.name,
           display_name: nameInput.value,
-          category: categoryInput.value,
-          content_type: file.type || "application/octet-stream",
+          category,
+          content_type: getDeliveryUploadContentType(file, category),
           file_size: file.size,
           sort_order: 0,
         },


### PR DESCRIPTION
## Related frontend PR

- Frontend ZIP labeling: https://github.com/petra66orii/openeire/pull/216

Deploy this backend PR first.

## What changed

- add a ZIP-specific validation path for `application/zip` and `application/x-zip-compressed`
- accept empty MIME and `application/octet-stream` only when the final safe extension is `.zip`, the category is Photographs or ZIP / archive, and ZIP remains enabled by the configured MIME policy
- canonicalize accepted ZIP uploads to `application/zip` before private R2 multipart initiation and exact `HeadObject` verification
- preserve direct browser-to-private-R2 upload, bounded concurrency, retries, cancellation, replacement/versioning and retention behavior
- preserve safe attachment-only five-minute downloads with basename-cleaned `.zip` filenames
- update admin accept/help text, client DTO format labels, tests and the delivery operations runbook

## Root cause

The upload serializer delegated to an exact MIME allowlist check before any ZIP filename/category handling. Windows ZIPs reporting `application/x-zip-compressed`, an empty MIME, or `application/octet-stream` therefore failed with `Unsupported delivery file type`. Adding those values to the general allowlist would have been unsafe, so this change uses a constrained ZIP-only fallback instead.

## Security and scope

- generic `application/octet-stream` remains rejected
- ZIP MIME on `.exe` or another final extension is rejected
- `.exe.zip` is accepted under the documented final-extension policy; archive contents are never inspected or extracted
- ZIPs are restricted to Photographs and ZIP / archive
- object keys remain generated, private, and absent from DTOs and public responses
- ZIP bytes continue to bypass Django and Next.js
- the existing 50 GiB file, 100-file, 10,000-part and four-worker limits are unchanged
- JPG, WebP, MP4 and PDF behavior is unchanged
- no migrations, environment changes, R2 changes, secrets, client data, generated artefacts or unrelated files

## Deployment order

1. Deploy this backend PR first.
2. Complete backend health/system checks and a staff ZIP upload smoke test.
3. Deploy the companion frontend PR only after the backend DTO can supply `format_label`.
4. No Render variable or R2 configuration change is required.

The frontend remains backward-compatible if it is deployed first, but backend-first is the supported rollout order so the ZIP label is available immediately.

## Production test procedure

1. Use a fictional/test delivery and client-safe filename; do not use production client data for the smoke test.
2. In **Upload media**, select **Photographs**, enter `Complete photograph package`, and upload a `.zip` fixture.
3. On Windows, confirm `application/x-zip-compressed`, empty MIME, or `application/octet-stream` follows the constrained ZIP path; confirm the stored upload session and R2 object type are canonical `application/zip`.
4. Confirm the browser uploads parts directly to private R2, concurrency remains bounded, completion performs `HeadObject`, and no object key or signed URL appears in the response, DTO, audit, or logs.
5. Confirm `.exe` with ZIP MIME and non-ZIP octet-stream fail, while `.exe.zip` follows the documented final-extension policy.
6. Complete and replace a ZIP upload; confirm only the verified new version becomes active.
7. After the frontend rollout, open the recipient portal and confirm `Complete photograph package — ZIP archive` appears without an image preview.
8. Initiate the download by POST; confirm the controlled five-minute R2 URL uses attachment disposition with the safe original `.zip` filename and file bytes do not traverse Django or Next.js.
9. Re-test one JPG, WebP, MP4 and PDF upload.
10. Revoke/expire the test delivery and confirm existing policy and retention behavior remains unchanged.

## Validation

- focused Django delivery tests: 50 passed
- JavaScript multipart-uploader tests: 18 passed
- complete backend suite: 563 passed
- portal system checks enabled and disabled: passed with test settings
- migration drift: no changes detected
- Python compilation: passed
- admin uploader template loading: passed
- `git diff --check`: passed