### PR TITLE
Update real estate package prices and inclusion rules

### DIFF
--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -47,6 +47,7 @@ from .finance import can_release_realestate_delivery, create_realestate_balance_
 from .stripe_invoices import create_stripe_invoice, mark_stripe_invoice_paid_out_of_band, send_stripe_invoice
 from .payments import calculate_realestate_deposit_amounts
 from .payments import prepare_realestate_deposit_checkout_session
+from .package_catalogue import get_included_add_ons
 from .timeline import record_timeline_event
 from .financial_documents import (
     build_invoice_filename, build_receipt_filename,
@@ -55,6 +56,37 @@ from .financial_documents import (
 
 
 logger = logging.getLogger(__name__)
+
+
+class RealEstateEnquiryAdminForm(forms.ModelForm):
+    class Meta:
+        model = RealEstateEnquiry
+        fields = "__all__"
+
+    def clean(self):
+        cleaned_data = super().clean()
+        package = cleaned_data.get("preferred_package")
+        add_ons = set(cleaned_data.get("add_ons") or [])
+        conflicts = add_ons & get_included_add_ons(package)
+        instance_is_historical = bool(
+            self.instance.pk
+            and (
+                self.instance.status in {
+                    RealEstateEnquiry.Status.BOOKED,
+                    RealEstateEnquiry.Status.COMPLETED,
+                }
+                or self.instance.booking_agreement_snapshots.exists()
+            )
+        )
+        if conflicts and not instance_is_historical:
+            labels = ", ".join(
+                RealEstateEnquiry.ADD_ON_LABELS[key] for key in sorted(conflicts)
+            )
+            self.add_error(
+                "add_ons",
+                f"Already included with the selected package: {labels}.",
+            )
+        return cleaned_data
 
 
 class RealEstateTimelineEventInline(admin.TabularInline):
@@ -162,6 +194,7 @@ class RealEstateDeliveryOverrideInline(admin.TabularInline):
 
 @admin.register(RealEstateEnquiry, site=custom_admin_site)
 class RealEstateEnquiryAdmin(admin.ModelAdmin):
+    form = RealEstateEnquiryAdminForm
     change_form_template = "admin/realestate/enquiry/change_form.html"
     EMAIL_TIMELINE_EVENTS = {
         "quote": (

--- a/realestate/docs/package_catalogue_rollout.md
+++ b/realestate/docs/package_catalogue_rollout.md
@@ -2,18 +2,19 @@
 
 ## Effective scope
 
-The photograph allowances in `realestate.package_catalogue` apply to enquiries
-quoted or contracted after the backend catalogue release is deployed:
+The package rules in `realestate.package_catalogue` apply to enquiries quoted
+or contracted after the backend catalogue release is deployed:
 
-- Essential: 10 professionally edited interior and exterior photographs
-- Starter: 25 professionally edited interior and exterior photographs
-- Pro: 30 professionally edited interior and exterior photographs
-- Premium: 35 professionally edited interior and exterior photographs
+- Essential: EUR 175; 10 ground photographs
+- Starter: EUR 259; 25 ground photographs, 5-8 additional aerial stills and a measured 2D floor plan
+- Pro: EUR 419; 30 ground photographs, 5-8 additional aerial stills, a measured 2D floor plan, ground video, separate 4K drone video and one vertical 9:16 social video
+- Premium: EUR 549; 35 ground photographs, 5-8 additional aerial stills, a measured 2D floor plan, ground video, separate 4K drone video, one vertical 9:16 social video and a hosted 3D tour
 - Custom / Not sure: specifically agreed
 
-Package prices, other deliverables, add-ons, travel rules, and package-aware
-turnaround are unchanged. Additional edited photographs remain EUR 10 per
-photograph.
+Additional edited photographs remain EUR 10 per photograph. The EUR 75 floor-plan
+add-on is available for Essential and suitable Custom work, and is rejected as a
+duplicate selection for Starter, Pro and Premium. Alternative social formats,
+additional cuts and extra edits remain available for EUR 50.
 
 ## Historical protection
 

--- a/realestate/models.py
+++ b/realestate/models.py
@@ -12,6 +12,7 @@ from .package_catalogue import (
     PACKAGE_SUMMARIES,
     get_included_photograph_count,
     get_included_photographs_label,
+    get_included_add_ons,
     get_package_summary,
 )
 from .turnaround import (
@@ -146,11 +147,13 @@ class RealEstateEnquiry(models.Model):
 
     ADD_ON_LABELS = {
         "additional_stills": "Additional edited photographs - EUR 10 per photograph",
-        "floor_plan": "Floor plan, 2D measured - EUR 75",
+        "floor_plan": "Measured 2D floor plan - EUR 75",
         "virtual_tour_3d": "Hosted 3D virtual tour - EUR 150",
         "rush_delivery": "Rush same-day delivery, still photography only - EUR 75",
         "extended_drone_video": "Extended drone video, up to 3 minutes - EUR 150",
-        "additional_social_cuts": "Additional social media cuts - EUR 50",
+        "additional_social_cuts": (
+            "Additional social-media cuts, alternative formats or additional edits - EUR 50"
+        ),
         "travel_supplement": "Travel supplement beyond 40 km - EUR 0.50 per km",
     }
 
@@ -415,7 +418,14 @@ class RealEstateEnquiry(models.Model):
 
     def get_add_on_labels(self):
         labels = []
+        included_add_ons = (
+            frozenset()
+            if self._get_persisted_package_scope() or self._requires_historical_scope_review()
+            else get_included_add_ons(self.preferred_package)
+        )
         for key in self.add_ons or []:
+            if key in included_add_ons:
+                continue
             label = self.ADD_ON_LABELS.get(key, key)
             if key == "additional_stills" and self.additional_stills_quantity:
                 label = f"{label} x {self.additional_stills_quantity}"

--- a/realestate/package_catalogue.py
+++ b/realestate/package_catalogue.py
@@ -13,6 +13,7 @@ class RealEstatePackage:
     price_eur: int | None
     included_photographs: int | None
     other_deliverables: str = ""
+    included_add_ons: frozenset[str] = frozenset()
 
     @property
     def included_photographs_label(self):
@@ -20,7 +21,7 @@ class RealEstatePackage:
             return "Included photographs as specifically agreed"
         return (
             f"{self.included_photographs} professionally edited interior "
-            "and exterior photographs"
+            "and exterior ground photographs"
         )
 
     @property
@@ -40,27 +41,36 @@ REAL_ESTATE_PACKAGE_CATALOGUE = {
     ),
     "starter": RealEstatePackage(
         name="Starter",
-        price_eur=229,
+        price_eur=259,
         included_photographs=25,
-        other_deliverables="5-8 aerial drone photographs",
+        other_deliverables=(
+            "5-8 aerial drone stills in addition to the ground photographs + "
+            "2D measured floor plan"
+        ),
+        included_add_ons=frozenset({"floor_plan"}),
     ),
     "pro": RealEstatePackage(
         name="Pro",
-        price_eur=399,
+        price_eur=419,
         included_photographs=30,
         other_deliverables=(
-            "5-8 aerial drone photographs + 60-90s ground video + "
-            "60-90s 4K aerial drone video + standard portrait and square social cuts"
+            "5-8 aerial drone stills in addition to the ground photographs + "
+            "2D measured floor plan + 60-90s ground video + separate 60-90s "
+            "4K aerial drone video + one vertical 9:16 social-media video"
         ),
+        included_add_ons=frozenset({"floor_plan"}),
     ),
     "premium": RealEstatePackage(
         name="Premium",
-        price_eur=579,
+        price_eur=549,
         included_photographs=35,
         other_deliverables=(
-            "5-8 aerial drone photographs + ground video + aerial drone video + "
-            "standard social cuts + hosted 3D virtual tour + 2D measured floor plan"
+            "5-8 aerial drone stills in addition to the ground photographs + "
+            "2D measured floor plan + 60-90s ground video + separate 60-90s "
+            "4K aerial drone video + one vertical 9:16 social-media video + "
+            "hosted 3D virtual tour"
         ),
+        included_add_ons=frozenset({"floor_plan", "virtual_tour_3d"}),
     ),
     "custom": RealEstatePackage(
         name="Custom",
@@ -97,3 +107,8 @@ def get_included_photographs_label(package_code, fallback="Specifically agreed")
 def get_included_photograph_count(package_code):
     package = get_package(package_code)
     return package.included_photographs if package else None
+
+
+def get_included_add_ons(package_code):
+    package = get_package(package_code)
+    return package.included_add_ons if package else frozenset()

--- a/realestate/serializers.py
+++ b/realestate/serializers.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from rest_framework import serializers
 
 from .models import RealEstateEnquiry
+from .package_catalogue import get_included_add_ons
 
 
 IRISH_COUNTIES = (
@@ -41,13 +42,6 @@ class RealEstateEnquirySerializer(serializers.ModelSerializer):
         "property_features", "access_contact_name", "access_contact_phone",
         "access_notes", "on_camera_people", "audio_requirements", "message",
     )
-    PACKAGE_ADD_ON_CONFLICTS = {
-        RealEstateEnquiry.PreferredPackage.PRO: {"additional_social_cuts"},
-        RealEstateEnquiry.PreferredPackage.PREMIUM: {
-            "floor_plan", "virtual_tour_3d", "additional_social_cuts",
-        },
-    }
-
     # These were unrestricted strings in the deployed legacy form. V2 choices
     # are enforced in validate() so old clients are not rejected mid-rollout.
     county = serializers.CharField(max_length=100)
@@ -161,6 +155,15 @@ class RealEstateEnquirySerializer(serializers.ModelSerializer):
             if not attrs.get(field_name):
                 errors[field_name] = "This field may not be blank."
 
+        add_ons = set(attrs.get("add_ons") or [])
+        package = attrs.get("preferred_package")
+        conflicts = add_ons & get_included_add_ons(package)
+        if conflicts:
+            labels = ", ".join(
+                RealEstateEnquiry.ADD_ON_LABELS[key] for key in sorted(conflicts)
+            )
+            errors["add_ons"] = f"Already included with the selected package: {labels}."
+
         if not self._is_v2(attrs):
             if errors:
                 raise serializers.ValidationError(errors)
@@ -264,7 +267,6 @@ class RealEstateEnquirySerializer(serializers.ModelSerializer):
                     "Describe the spoken-audio or microphone requirements."
                 )
 
-        add_ons = set(attrs.get("add_ons") or [])
         quantity = attrs.get("additional_stills_quantity")
         if "additional_stills" in add_ons and quantity is None:
             errors["additional_stills_quantity"] = (
@@ -274,14 +276,6 @@ class RealEstateEnquirySerializer(serializers.ModelSerializer):
             errors["additional_stills_quantity"] = (
                 "Only provide a quantity when additional stills are selected."
             )
-        package = attrs.get("preferred_package")
-        conflicts = add_ons & self.PACKAGE_ADD_ON_CONFLICTS.get(package, set())
-        if conflicts:
-            labels = ", ".join(
-                RealEstateEnquiry.ADD_ON_LABELS[key] for key in sorted(conflicts)
-            )
-            errors["add_ons"] = f"Already included with the selected package: {labels}."
-
         if errors:
             raise serializers.ValidationError(errors)
         return attrs

--- a/realestate/tests.py
+++ b/realestate/tests.py
@@ -61,7 +61,7 @@ REAL_ESTATE_EMAIL_TEMPLATE_CONTEXT = {
     "property_address": "Example House, Salthill, Galway",
     "package_name": "Pro package",
     "included_photographs_label": (
-        "30 professionally edited interior and exterior photographs"
+        "30 professionally edited interior and exterior ground photographs"
     ),
     "additional_photograph_copy": (
         "Additional edited photographs may be agreed at EUR 10 per photograph."
@@ -209,6 +209,24 @@ class RealEstatePricingTests(TestCase):
         self.assertEqual(amounts["vat_total"], Decimal("91.77"))
         self.assertEqual(amounts["total_including_vat"], Decimal("490.77"))
         self.assertEqual(amounts["deposit_amount"], Decimal("147.23"))
+
+    @override_settings(VAT_REGISTERED=False)
+    def test_updated_package_totals_use_the_existing_30_percent_deposit_rule(self):
+        for package_code, total, deposit, balance in (
+            ("essential", "175.00", "52.50", "122.50"),
+            ("starter", "259.00", "77.70", "181.30"),
+            ("pro", "419.00", "125.70", "293.30"),
+            ("premium", "549.00", "164.70", "384.30"),
+        ):
+            with self.subTest(package=package_code):
+                enquiry = self._enquiry(
+                    preferred_package=package_code,
+                    quoted_price=Decimal(total),
+                )
+                amounts = calculate_realestate_deposit_amounts(enquiry)
+                self.assertEqual(amounts["total_including_vat"], Decimal(total))
+                self.assertEqual(amounts["deposit_amount"], Decimal(deposit))
+                self.assertEqual(amounts["balance_due"], Decimal(balance))
 
 
 @override_settings(STRIPE_SECRET_KEY="sk_test_deposit_sessions")
@@ -601,7 +619,7 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
                 )
                 for rendered in (html, text):
                     self.assertIn(
-                        "30 professionally edited interior and exterior photographs",
+                        "30 professionally edited interior and exterior ground photographs",
                         rendered,
                     )
                     self.assertIn("EUR 10 per photograph", rendered)
@@ -624,7 +642,7 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
                 text = render_to_string("emails/real_estate/quote.txt", context)
                 expected_copy = (
                     f"{expected} professionally edited interior and exterior "
-                    "photographs"
+                    "ground photographs"
                 )
                 self.assertIn(expected_copy, html)
                 self.assertIn(expected_copy, text)
@@ -1373,7 +1391,7 @@ class BookingAgreementDocumentTests(TestCase):
             county="Galway",
             eircode="H91 LONG",
             property_type="Detached house",
-            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            preferred_package=RealEstateEnquiry.PreferredPackage.ESSENTIAL,
             preferred_date="2026-06-20",
             shoot_date="2026-06-20",
             shoot_time="10:30",
@@ -1410,8 +1428,11 @@ class BookingAgreementDocumentTests(TestCase):
             "| Access notes / restrictions | Use the courtyard entrance and call on arrival |",
             rendered,
         )
-        self.assertIn("Floor plan, 2D measured - €75", rendered)
-        self.assertIn("Additional social media cuts - €50", rendered)
+        self.assertIn("Measured 2D floor plan - €75", rendered)
+        self.assertIn(
+            "Additional social-media cuts, alternative formats or additional edits - €50",
+            rendered,
+        )
         self.assertIn("Travel supplement beyond 40 km - €0.50 per km", rendered)
         self.assertIn("| Travel supplement applies | Yes - included in the quoted services total |", rendered)
         self.assertIn("| Travel supplement included | €65.00 |", rendered)
@@ -1449,7 +1470,7 @@ class BookingAgreementDocumentTests(TestCase):
         snapshot = RealEstateBookingAgreementSnapshot.objects.get(enquiry=enquiry)
         self.assertEqual(snapshot.template_version, "1.8")
         self.assertIn(
-            "30 professionally edited interior and exterior photographs",
+            "30 professionally edited interior and exterior ground photographs",
             first,
         )
         self.assertEqual(snapshot.payment_arrangement, RealEstateEnquiry.PaymentArrangement.FULL_ON_SHOOT_DAY)
@@ -1466,7 +1487,7 @@ class BookingAgreementDocumentTests(TestCase):
             property_address="Example House",
             county="Galway",
             property_type="Detached house",
-            preferred_package=RealEstateEnquiry.PreferredPackage.PRO,
+            preferred_package=RealEstateEnquiry.PreferredPackage.ESSENTIAL,
             quoted_price="399.00",
             add_ons=["floor_plan"],
             consent_to_contact=True,
@@ -1498,7 +1519,7 @@ class BookingAgreementDocumentTests(TestCase):
         self.assertEqual(issued_snapshot.template_version, "1.8")
         self.assertEqual(new_snapshot.template_version, "1.8")
         self.assertNotIn("Travel supplement beyond 40 km", issued_markdown)
-        self.assertIn("Floor plan, 2D measured - €75", new_markdown)
+        self.assertIn("Measured 2D floor plan - €75", new_markdown)
         self.assertIn("Travel supplement beyond 40 km - €0.50 per km", new_markdown)
         self.assertIn("| Travel supplement included | €65.00 |", new_markdown)
         self.assertEqual(enquiry.booking_agreement_snapshots.count(), 2)
@@ -1613,7 +1634,7 @@ class BookingAgreementDocumentTests(TestCase):
             county="Galway",
             property_type="Apartment",
             preferred_package=RealEstateEnquiry.PreferredPackage.STARTER,
-            quoted_price="294.00",
+            quoted_price="324.00",
             add_ons=["travel_supplement"],
             consent_to_contact=True,
         )
@@ -1629,9 +1650,9 @@ class BookingAgreementDocumentTests(TestCase):
         enquiry.save(update_fields=["travel_supplement_amount", "travel_details"])
         rendered = render_booking_agreement_markdown(enquiry)
 
-        self.assertIn("Starter - €229", rendered)
+        self.assertIn("Starter - €259", rendered)
         self.assertIn("| Travel supplement included | €65.00 |", rendered)
-        self.assertIn("| Quoted services total | €294.00 |", rendered)
+        self.assertIn("| Quoted services total | €324.00 |", rendered)
         self.assertIn(enquiry.travel_details, rendered)
 
 
@@ -1733,7 +1754,7 @@ class RealEstateEnquiryTests(APITestCase):
             "access_provider": "enquirer",
             "readiness_acknowledged": True,
             "preferred_package": "pro",
-            "add_ons": ["floor_plan"],
+            "add_ons": [],
             "scheduling_preference": "request_date",
             "preferred_date": (timezone.localdate() + timedelta(days=14)).isoformat(),
             "preferred_time_window": "morning",
@@ -1767,7 +1788,7 @@ class RealEstateEnquiryTests(APITestCase):
         self.assertEqual(response.data["included_photograph_count"], 30)
         self.assertEqual(
             response.data["included_photographs_label"],
-            "30 professionally edited interior and exterior photographs",
+            "30 professionally edited interior and exterior ground photographs",
         )
         self.assertNotIn("internal_notes", response.data)
         for private_pricing_field in (
@@ -2122,7 +2143,8 @@ class RealEstateEnquiryTests(APITestCase):
 
     def test_package_inclusions_cannot_be_selected_as_add_ons(self):
         for package, add_on in (
-            ("pro", "additional_social_cuts"),
+            ("starter", "floor_plan"),
+            ("pro", "floor_plan"),
             ("premium", "floor_plan"),
             ("premium", "virtual_tour_3d"),
         ):
@@ -2138,6 +2160,52 @@ class RealEstateEnquiryTests(APITestCase):
                 )
                 self.assertEqual(response.status_code, 400)
                 self.assertIn("add_ons", response.data)
+
+    def test_floor_plan_add_on_remains_available_for_essential_and_custom(self):
+        for package in ("essential", "custom"):
+            with self.subTest(package=package):
+                response = self.client.post(
+                    self.url,
+                    data={
+                        **self.payload,
+                        "email": f"{package}@example.com",
+                        "preferred_package": package,
+                        "add_ons": ["floor_plan"],
+                    },
+                    format="json",
+                )
+                self.assertEqual(response.status_code, 201)
+
+    def test_additional_social_video_work_remains_available_for_pro_and_premium(self):
+        for package in ("pro", "premium"):
+            with self.subTest(package=package):
+                response = self.client.post(
+                    self.url,
+                    data={
+                        **self.payload,
+                        "email": f"social-{package}@example.com",
+                        "preferred_package": package,
+                        "add_ons": ["additional_social_cuts"],
+                    },
+                    format="json",
+                )
+                self.assertEqual(response.status_code, 201)
+
+    def test_new_package_summary_omits_a_manually_stored_duplicate_floor_plan(self):
+        enquiry = RealEstateEnquiry.objects.create(
+            name="Manual record",
+            email="manual@example.com",
+            phone="+353871234567",
+            client_type="private_seller",
+            property_address="Manual address",
+            county="Galway",
+            property_type="house",
+            preferred_package="starter",
+            consent_to_contact=True,
+            add_ons=["floor_plan"],
+        )
+
+        self.assertEqual(enquiry.get_add_ons_summary(), "None")
 
     def test_public_travel_selection_is_rejected_but_model_support_remains(self):
         response = self.client.post(
@@ -2163,9 +2231,12 @@ class RealEstateEnquiryTests(APITestCase):
         self.assertEqual(historical.add_ons, ["travel_supplement"])
 
     def test_current_package_summaries_include_ground_video_and_floor_plan(self):
+        self.assertIn("2D measured floor plan", RealEstateEnquiry.PACKAGE_SUMMARIES["starter"])
         self.assertIn("ground video", RealEstateEnquiry.PACKAGE_SUMMARIES["pro"])
+        self.assertIn("vertical 9:16 social-media video", RealEstateEnquiry.PACKAGE_SUMMARIES["pro"])
         self.assertIn("ground video", RealEstateEnquiry.PACKAGE_SUMMARIES["premium"])
         self.assertIn("2D measured floor plan", RealEstateEnquiry.PACKAGE_SUMMARIES["premium"])
+        self.assertIn("vertical 9:16 social-media video", RealEstateEnquiry.PACKAGE_SUMMARIES["premium"])
 
     def test_authoritative_package_catalogue_preserves_prices_and_new_allowances(self):
         self.assertEqual(
@@ -2175,9 +2246,9 @@ class RealEstateEnquiryTests(APITestCase):
             },
             {
                 "essential": (175, 10),
-                "starter": (229, 25),
-                "pro": (399, 30),
-                "premium": (579, 35),
+                "starter": (259, 25),
+                "pro": (419, 30),
+                "premium": (549, 35),
                 "custom": (None, None),
                 "not_sure": (None, None),
             },
@@ -2190,7 +2261,7 @@ class RealEstateEnquiryTests(APITestCase):
             "premium": 35,
         }.items():
             self.assertIn(
-                f"{expected} professionally edited interior and exterior photographs",
+                f"{expected} professionally edited interior and exterior ground photographs",
                 RealEstateEnquiry.PACKAGE_SUMMARIES[code],
             )
 


### PR DESCRIPTION
## Summary

- updates the active real-estate package catalogue prices and deliverable summaries
- includes measured floor plans for Starter, Pro and Premium
- rejects duplicate included add-ons through API and admin validation
- preserves historical agreement snapshots and recorded financial totals
- keeps additional social formats available as paid custom work

## Validation

- 182 real-estate and finance tests
- Django system check
- migration consistency check (no changes detected)
- `git diff --check`