### PR TITLE
Clarify combined property film package wording

### DIFF
--- a/realestate/docs/package_catalogue_rollout.md
+++ b/realestate/docs/package_catalogue_rollout.md
@@ -7,8 +7,8 @@ or contracted after the backend catalogue release is deployed:
 
 - Essential: EUR 175; 10 ground photographs
 - Starter: EUR 259; 25 ground photographs, 5-8 additional aerial stills and a measured 2D floor plan
-- Pro: EUR 419; 30 ground photographs, 5-8 additional aerial stills, a measured 2D floor plan, ground video, separate 4K drone video and one vertical 9:16 social video
-- Premium: EUR 549; 35 ground photographs, 5-8 additional aerial stills, a measured 2D floor plan, ground video, separate 4K drone video, one vertical 9:16 social video and a hosted 3D tour
+- Pro: EUR 419; 30 ground photographs, 5-8 additional aerial stills, a measured 2D floor plan, One combined 4K property film — 60–90 sec ground footage + 60–90 sec aerial footage (approx. 2–3 min total), and one separate vertical 9:16 social video
+- Premium: EUR 549; 35 ground photographs, 5-8 additional aerial stills, a measured 2D floor plan, One combined 4K property film — 60–90 sec ground footage + 60–90 sec aerial footage (approx. 2–3 min total), one separate vertical 9:16 social video and a hosted 3D tour
 - Custom / Not sure: specifically agreed
 
 Additional edited photographs remain EUR 10 per photograph. The EUR 75 floor-plan

--- a/realestate/package_catalogue.py
+++ b/realestate/package_catalogue.py
@@ -5,6 +5,10 @@ ADDITIONAL_PHOTOGRAPH_PRICE_EUR = 10
 ADDITIONAL_PHOTOGRAPH_COPY = (
     "Additional edited photographs may be agreed at EUR 10 per photograph."
 )
+COMBINED_PROPERTY_VIDEO_DELIVERABLE = (
+    "One combined 4K property film — 60–90 sec ground footage + 60–90 sec "
+    "aerial footage (approx. 2–3 min total)"
+)
 
 
 @dataclass(frozen=True)
@@ -55,8 +59,8 @@ REAL_ESTATE_PACKAGE_CATALOGUE = {
         included_photographs=30,
         other_deliverables=(
             "5-8 aerial drone stills in addition to the ground photographs + "
-            "2D measured floor plan + 60-90s ground video + separate 60-90s "
-            "4K aerial drone video + one vertical 9:16 social-media video"
+            f"2D measured floor plan + {COMBINED_PROPERTY_VIDEO_DELIVERABLE} + "
+            "one vertical 9:16 social-media video"
         ),
         included_add_ons=frozenset({"floor_plan"}),
     ),
@@ -66,8 +70,8 @@ REAL_ESTATE_PACKAGE_CATALOGUE = {
         included_photographs=35,
         other_deliverables=(
             "5-8 aerial drone stills in addition to the ground photographs + "
-            "2D measured floor plan + 60-90s ground video + separate 60-90s "
-            "4K aerial drone video + one vertical 9:16 social-media video + "
+            f"2D measured floor plan + {COMBINED_PROPERTY_VIDEO_DELIVERABLE} + "
+            "one vertical 9:16 social-media video + "
             "hosted 3D virtual tour"
         ),
         included_add_ons=frozenset({"floor_plan", "virtual_tour_3d"}),

--- a/realestate/tests.py
+++ b/realestate/tests.py
@@ -646,6 +646,14 @@ class RealEstateEmailTemplateTests(SimpleTestCase):
                 )
                 self.assertIn(expected_copy, html)
                 self.assertIn(expected_copy, text)
+                if package_code in {"pro", "premium"}:
+                    for rendered in (html, text):
+                        self.assertIn(
+                            "One combined 4K property film — 60–90 sec ground footage + "
+                            "60–90 sec aerial footage (approx. 2–3 min total)",
+                            rendered,
+                        )
+                        self.assertNotIn("separate 60–90", rendered)
 
     def test_base_template_renders_logo_when_logo_url_exists(self):
         html = render_to_string(
@@ -1175,9 +1183,16 @@ class BookingAgreementDocumentTests(TestCase):
         )
 
         pdf_bytes = generate_booking_agreement_pdf(enquiry)
+        rendered = self._render_booking_agreement_markdown(enquiry)
 
         self.assertTrue(pdf_bytes.startswith(b"%PDF"))
         self.assertGreater(len(pdf_bytes), 1000)
+        self.assertIn(
+            "One combined 4K property film — 60–90 sec ground footage + "
+            "60–90 sec aerial footage (approx. 2–3 min total)",
+            rendered,
+        )
+        self.assertNotIn("separate 60–90", rendered)
         self.assertEqual(
             build_booking_agreement_filename(enquiry),
             f"openeire-booking-agreement-re-{enquiry.id}-jane-agent.pdf",
@@ -1780,6 +1795,11 @@ class RealEstateEnquiryTests(APITestCase):
                 RealEstateEnquiry.PreferredPackage.PRO
             ],
         )
+        self.assertIn(
+            "One combined 4K property film — 60–90 sec ground footage + "
+            "60–90 sec aerial footage (approx. 2–3 min total)",
+            response.data["package_summary"],
+        )
         self.assertEqual(response.data["turnaround_code"], TWO_BUSINESS_DAYS)
         self.assertEqual(
             response.data["turnaround_label"],
@@ -2230,13 +2250,19 @@ class RealEstateEnquiryTests(APITestCase):
         )
         self.assertEqual(historical.add_ons, ["travel_supplement"])
 
-    def test_current_package_summaries_include_ground_video_and_floor_plan(self):
+    def test_current_package_summaries_describe_one_combined_property_video(self):
         self.assertIn("2D measured floor plan", RealEstateEnquiry.PACKAGE_SUMMARIES["starter"])
-        self.assertIn("ground video", RealEstateEnquiry.PACKAGE_SUMMARIES["pro"])
-        self.assertIn("vertical 9:16 social-media video", RealEstateEnquiry.PACKAGE_SUMMARIES["pro"])
-        self.assertIn("ground video", RealEstateEnquiry.PACKAGE_SUMMARIES["premium"])
+        expected_video = (
+            "One combined 4K property film — 60–90 sec ground footage + "
+            "60–90 sec aerial footage (approx. 2–3 min total)"
+        )
+        for package_code in ("pro", "premium"):
+            summary = RealEstateEnquiry.PACKAGE_SUMMARIES[package_code]
+            self.assertIn(expected_video, summary)
+            self.assertIn("vertical 9:16 social-media video", summary)
+            self.assertNotIn("separate 60", summary)
         self.assertIn("2D measured floor plan", RealEstateEnquiry.PACKAGE_SUMMARIES["premium"])
-        self.assertIn("vertical 9:16 social-media video", RealEstateEnquiry.PACKAGE_SUMMARIES["premium"])
+        self.assertIn("hosted 3D virtual tour", RealEstateEnquiry.PACKAGE_SUMMARIES["premium"])
 
     def test_authoritative_package_catalogue_preserves_prices_and_new_allowances(self):
         self.assertEqual(


### PR DESCRIPTION
## What changed

- Updated the canonical Pro and Premium package catalogue wording to: `One combined 4K property film — 60–90 sec ground footage + 60–90 sec aerial footage (approx. 2–3 min total)`
- Preserved the vertical 9:16 social-media video as a separate deliverable
- Kept Pro at EUR 419 and Premium at EUR 549
- Updated rollout documentation and coverage for API responses, emails, booking agreements, and generated PDFs
- Historical package snapshots remain unchanged

## Verification

- `python manage.py test realestate.tests.RealEstatePricingTests realestate.tests.RealEstateEmailTemplateTests realestate.tests.BookingAgreementDocumentTests realestate.tests.RealEstateEnquiryTests --settings=openeire_api.settings_test -v 1` — 72 tests passed
- `python manage.py makemigrations --check --dry-run --skip-checks` — no changes detected
- Obsolete production wording searches — no matches
- `git diff --check` — passed