### PR TITLE
Fix real-estate Stripe Checkout URL storage

### DIFF
--- a/realestate/admin.py
+++ b/realestate/admin.py
@@ -1550,6 +1550,10 @@ class RealEstateEnquiryAdmin(admin.ModelAdmin):
             try:
                 checkout = prepare_realestate_deposit_checkout_session(enquiry)
             except Exception as exc:
+                logger.exception(
+                    "Real estate deposit checkout preparation failed. enquiry_id=%s",
+                    enquiry.pk,
+                )
                 failed_count += 1
                 warnings.append(
                     f"{enquiry}: deposit checkout preparation failed "

--- a/realestate/migrations/0027_widen_stripe_url_fields.py
+++ b/realestate/migrations/0027_widen_stripe_url_fields.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("realestate", "0026_realestatedelivery_public_id"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="realestateenquiry",
+            name="deposit_payment_link",
+            field=models.URLField(blank=True, max_length=2048),
+        ),
+        migrations.AlterField(
+            model_name="realestateinvoice",
+            name="stripe_checkout_url",
+            field=models.URLField(blank=True, max_length=2048),
+        ),
+        migrations.AlterField(
+            model_name="realestateinvoice",
+            name="stripe_hosted_invoice_url",
+            field=models.URLField(blank=True, max_length=2048),
+        ),
+        migrations.AlterField(
+            model_name="realestateinvoice",
+            name="stripe_invoice_pdf_url",
+            field=models.URLField(blank=True, max_length=2048),
+        ),
+    ]

--- a/realestate/models.py
+++ b/realestate/models.py
@@ -311,7 +311,7 @@ class RealEstateEnquiry(models.Model):
 
     proposed_shoot_date = models.DateField(null=True, blank=True)
     booking_agreement_received = models.BooleanField(default=False)
-    deposit_payment_link = models.URLField(max_length=500, blank=True)
+    deposit_payment_link = models.URLField(max_length=2048, blank=True)
     stripe_deposit_session_id = models.CharField(max_length=255, blank=True)
     stripe_deposit_creation_key = models.CharField(max_length=255, blank=True)
     deposit_paid = models.BooleanField(default=False)
@@ -642,8 +642,8 @@ class RealEstateInvoice(models.Model):
     paid_at = models.DateTimeField(null=True, blank=True)
     stripe_invoice_id = models.CharField(max_length=255, blank=True)
     stripe_invoice_number = models.CharField(max_length=255, blank=True)
-    stripe_hosted_invoice_url = models.URLField(max_length=500, blank=True)
-    stripe_invoice_pdf_url = models.URLField(max_length=500, blank=True)
+    stripe_hosted_invoice_url = models.URLField(max_length=2048, blank=True)
+    stripe_invoice_pdf_url = models.URLField(max_length=2048, blank=True)
     stripe_invoice_status = models.CharField(max_length=32, blank=True)
     stripe_invoice_created_at = models.DateTimeField(null=True, blank=True)
     stripe_invoice_finalized_at = models.DateTimeField(null=True, blank=True)
@@ -653,7 +653,7 @@ class RealEstateInvoice(models.Model):
         related_name="realestate_invoices_marked_paid_out_of_band",
     )
     stripe_checkout_session_id = models.CharField(max_length=255, blank=True)
-    stripe_checkout_url = models.URLField(max_length=500, blank=True)
+    stripe_checkout_url = models.URLField(max_length=2048, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/realestate/tests.py
+++ b/realestate/tests.py
@@ -463,6 +463,33 @@ class RealEstateDepositCheckoutSessionTests(TestCase):
         self.assertEqual(self.enquiry.stripe_deposit_creation_key, "")
 
     @patch("realestate.payments.stripe.checkout.Session.create")
+    def test_checkout_preparation_persists_url_longer_than_500_characters(
+        self, mock_create
+    ):
+        self.enquiry.stripe_deposit_session_id = ""
+        self.enquiry.deposit_payment_link = ""
+        self.enquiry.save(
+            update_fields=("stripe_deposit_session_id", "deposit_payment_link")
+        )
+        checkout_url = "https://checkout.stripe.com/c/pay/" + ("a" * 600)
+        self.assertGreater(len(checkout_url), 500)
+        self.assertEqual(
+            RealEstateEnquiry._meta.get_field("deposit_payment_link").max_length,
+            2048,
+        )
+        mock_create.return_value = {
+            "id": "cs_test_long_checkout_url",
+            "url": checkout_url,
+        }
+
+        result = prepare_realestate_deposit_checkout_session(self.enquiry)
+
+        self.assertEqual(result.checkout_url, checkout_url)
+        self.enquiry.refresh_from_db()
+        self.assertEqual(self.enquiry.deposit_payment_link, checkout_url)
+        self.assertEqual(len(self.enquiry.deposit_payment_link), len(checkout_url))
+
+    @patch("realestate.payments.stripe.checkout.Session.create")
     def test_permanent_creation_error_clears_attempt_key(self, mock_create):
         self.enquiry.stripe_deposit_session_id = ""
         self.enquiry.deposit_payment_link = ""


### PR DESCRIPTION
## Summary
- widen real-estate Stripe-controlled URL fields to 2048 characters
- add a regression test for Checkout URLs longer than 500 characters
- log deposit checkout preparation failures with full tracebacks

## Tests
- 13 targeted real-estate checkout/admin tests passed
- python manage.py makemigrations --check --dry-run